### PR TITLE
Working/0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # didwebvh-rs Changelog history
 
-## 15th August 2025
+## 18th August 2025
 
 ### Release 0.1.2
 
@@ -10,6 +10,7 @@ UpdateKey not propagating to new LogEntry Parameter set when pre-rotation is dis
 * **FIX:** Wizard would not reset an existing did.jsonl file for a new DID
 * **FIX:** Parameter method was always being placed in each LogEntry, will now
 correctly skip if version is the same
+* **MAINTENANCE:** More tests added for code coverage (@66.78% code coverage)
 
 ## 14th August 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 UpdateKey not propagating to new LogEntry Parameter set when pre-rotation is disabled
   * Secondary issue of changing update-key also results in an error
 * **FIX:** Wizard would not reset an existing did.jsonl file for a new DID
+* **FIX:** Parameter method was always being placed in each LogEntry, will now
+correctly skip if version is the same
 
 ## 14th August 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # didwebvh-rs Changelog history
 
+## 15th August 2025
+
+### Release 0.1.2
+
+* **FIX:** [Issue #5](https://github.com/decentralized-identity/didwebvh-rs/issues/5)
+UpdateKey not propagating to new LogEntry Parameter set when pre-rotation is disabled
+  * Secondary issue of changing update-key also results in an error
+* **FIX:** Wizard would not reset an existing did.jsonl file for a new DID
+
 ## 14th August 2025
 
 ### Release 0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -588,7 +588,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.105",
+ "syn 2.0.106",
  "which",
 ]
 
@@ -606,9 +606,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "bitmaps"
@@ -764,7 +764,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1059,7 +1059,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1382,7 +1382,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1453,7 +1453,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1486,7 +1486,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1512,7 +1512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1840,7 +1840,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ dependencies = [
  "enum-ordinalize 4.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2193,7 +2193,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2848,7 +2848,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cfg-if",
  "libc",
 ]
@@ -3431,7 +3431,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static-iref",
- "syn 2.0.105",
+ "syn 2.0.106",
  "thiserror 1.0.69",
 ]
 
@@ -3833,7 +3833,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3850,7 +3850,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4026,7 +4026,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4148,7 +4148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4430,7 +4430,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
 ]
 
 [[package]]
@@ -4450,7 +4450,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4732,7 +4732,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4745,7 +4745,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5019,7 +5019,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5032,7 +5032,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5157,7 +5157,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5274,7 +5274,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5286,7 +5286,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6404,7 +6404,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6423,7 +6423,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2 0.10.9",
- "syn 2.0.105",
+ "syn 2.0.106",
  "thiserror 1.0.69",
 ]
 
@@ -6464,9 +6464,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.105"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6508,7 +6508,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6528,7 +6528,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -6604,7 +6604,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6615,7 +6615,7 @@ checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6720,7 +6720,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6829,7 +6829,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -6872,7 +6872,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7175,7 +7175,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -7210,7 +7210,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7375,7 +7375,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7386,7 +7386,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
 ]
 
 [[package]]
@@ -7832,7 +7832,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
@@ -7853,7 +7853,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7873,7 +7873,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
@@ -7894,7 +7894,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7927,5 +7927,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,14 +113,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62839c92bdbc370f74dd7f20abe592c26aee8278031157006086c4fab4442a1d"
+checksum = "83e7aec463c67e4dd6412906baf5bb24a816c9e09594ca5608ca5cef2c77a4a9"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
  "did-peer",
- "did-webvh",
+ "didwebvh-rs 0.1.1",
  "futures-util",
  "highway",
  "moka",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1753,10 +1753,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "did-webvh"
-version = "0.1.7"
+name = "didwebvh-rs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622962fd46a4559d2325e5c0c4619ca6ee80f1c6fc28f01107075d9743eb7c58"
+checksum = "7f1d5cde5db0cca31f67472d22f247e0e497334c975f448202fa1818d2ed9253"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.10.9",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tracing",
 ]
 
@@ -105,7 +105,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi 0.11.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "uuid",
@@ -132,7 +132,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-rustls 0.26.2",
  "tracing",
@@ -159,7 +159,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi 0.11.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tracing",
  "uuid",
 ]
@@ -183,7 +183,7 @@ dependencies = [
  "sha2 0.10.9",
  "sha256",
  "ssi 0.11.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "uuid",
@@ -209,7 +209,7 @@ dependencies = [
  "serde_json",
  "sha256",
  "ssi 0.11.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -231,7 +231,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
 ]
@@ -278,7 +278,7 @@ dependencies = [
  "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
 ]
@@ -1690,7 +1690,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1772,7 +1772,7 @@ dependencies = [
  "serde_with 3.14.0",
  "sha2 0.10.9",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "url",
@@ -1804,7 +1804,7 @@ dependencies = [
  "serde_with 3.14.0",
  "sha2 0.10.9",
  "ssi 0.12.0",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2550,19 +2550,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2589,7 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "rustls 0.23.31",
  "rustls-pki-types",
@@ -2619,7 +2621,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2640,7 +2642,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4215,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -4256,7 +4258,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
  "socket2 0.5.10",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "web-time",
@@ -4277,7 +4279,7 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4570,7 +4572,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -6589,11 +6591,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
 dependencies = [
- "thiserror-impl 2.0.14",
+ "thiserror-impl 2.0.15",
 ]
 
 [[package]]
@@ -6609,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6679,9 +6681,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6961,7 +6963,7 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.1.1"
+version = "0.1.2"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-didwebvh-rs = "0.1.1"
+didwebvh-rs = "0.1.2"
 ```
 
 Then:

--- a/examples/wizard/updating/mod.rs
+++ b/examples/wizard/updating/mod.rs
@@ -118,8 +118,6 @@ pub async fn edit_did() -> Result<()> {
                     DIDWebVHError::LogEntryError("No new LogEntry created".to_string())
                 })?;
 
-                println!("TIMTAM: **** {new_entry:#?}");
-
                 let new_proofs = witness_log_entry(
                     &mut webvh_state.witness_proofs,
                     new_entry,

--- a/src/log_entry/mod.rs
+++ b/src/log_entry/mod.rs
@@ -214,9 +214,17 @@ impl LogEntry {
 
     /// Append a valid LogEntry to a file
     pub fn save_to_file(&self, file_path: &str) -> Result<(), DIDWebVHError> {
+        let append = if self.get_version_id_fields()?.0 == 1 {
+            false // Don't append to the file if this is the first version
+        } else {
+            true // Append to the file for all subsequent versions
+        };
+
         let mut file = OpenOptions::new()
             .create(true)
-            .append(true)
+            .write(true)
+            .truncate(!append)
+            .append(append)
             .open(file_path)
             .map_err(|e| {
                 DIDWebVHError::LogEntryError(format!("Couldn't open file {file_path}: {e}"))

--- a/src/log_entry/mod.rs
+++ b/src/log_entry/mod.rs
@@ -108,8 +108,6 @@ impl LogEntry {
             DIDWebVHError::LogEntryError(format!("Couldn't deserialize LogEntry. Reason: {e}"))
         })?;
 
-        println!("{values:#?}");
-
         // Step 2: Detect method version
         let version = if let Some(parameters) = values.get("parameters") {
             if let Some(method) = parameters.get("method") {

--- a/src/log_entry_state/mod.rs
+++ b/src/log_entry_state/mod.rs
@@ -105,4 +105,8 @@ impl LogEntryState {
             .clone()
             .map(|scid| scid.to_string())
     }
+
+    pub(crate) fn get_active_update_keys(&self) -> Arc<Vec<String>> {
+        self.validated_parameters.active_update_keys.clone()
+    }
 }

--- a/src/parameters/spec_1_0.rs
+++ b/src/parameters/spec_1_0.rs
@@ -80,7 +80,7 @@ impl From<Parameters> for Parameters1_0 {
         Parameters1_0 {
             deactivated: value.deactivated.unwrap_or_default(),
             pre_rotation_active: value.pre_rotation_active,
-            method: Some(Version::V1_0.to_string()),
+            method: value.method.map(|_| Version::V1_0.to_string()),
             next_key_hashes: value.next_key_hashes.clone(),
             scid: value.scid.clone(),
             ttl: value.ttl,
@@ -97,7 +97,7 @@ impl From<Parameters1_0> for Parameters {
         Parameters {
             deactivated: Some(value.deactivated),
             pre_rotation_active: value.pre_rotation_active,
-            method: Some(Version::V1_0),
+            method: value.method.map(|_| Version::V1_0),
             next_key_hashes: value.next_key_hashes.clone(),
             scid: value.scid.clone(),
             ttl: value.ttl,

--- a/src/parameters/spec_1_0_pre.rs
+++ b/src/parameters/spec_1_0_pre.rs
@@ -156,7 +156,7 @@ impl From<Parameters> for Parameters1_0Pre {
         Parameters1_0Pre {
             deactivated: value.deactivated.unwrap_or_default(),
             pre_rotation_active: value.pre_rotation_active,
-            method: Some(Version::V1_0Pre.to_string()),
+            method: value.method.map(|_| Version::V1_0Pre.to_string()),
             next_key_hashes,
             scid: value.scid.clone(),
             ttl,
@@ -203,7 +203,7 @@ impl From<Parameters1_0Pre> for Parameters {
         Parameters {
             deactivated: Some(value.deactivated),
             pre_rotation_active: value.pre_rotation_active,
-            method: Some(Version::V1_0),
+            method: value.method.map(|_| Version::V1_0),
             next_key_hashes,
             scid: value.scid.clone(),
             ttl,

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -174,17 +174,14 @@ impl DIDWebVHState {
                 let witness_proofs = if let Ok(proofs) = r2 {
                     match proofs {
                         Ok(proofs) => match proofs {
-                            Ok(proofs_string) => {
-                                println!("proofs ({proofs_string})");
-                                WitnessProofCollection {
-                                    proofs: serde_json::from_str(&proofs_string).map_err(|e| {
-                                        DIDWebVHError::WitnessProofError(format!(
-                                            "Couldn't deserialize Witness Proofs Data: {e}",
-                                        ))
-                                    })?,
-                                    ..Default::default()
-                                }
-                            }
+                            Ok(proofs_string) => WitnessProofCollection {
+                                proofs: serde_json::from_str(&proofs_string).map_err(|e| {
+                                    DIDWebVHError::WitnessProofError(format!(
+                                        "Couldn't deserialize Witness Proofs Data: {e}",
+                                    ))
+                                })?,
+                                ..Default::default()
+                            },
                             Err(e) => {
                                 warn!("Error downloading witness proofs: {e}");
                                 WitnessProofCollection::default()

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -240,3 +240,44 @@ impl DIDWebVHState {
         .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::DIDWebVHState;
+
+    #[tokio::test]
+    async fn resolve_reference() {
+        let mut webvh = DIDWebVHState::default();
+
+        let result = webvh.resolve(
+            "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs",
+            None,
+        ).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_reference_specific_version() {
+        let mut webvh = DIDWebVHState::default();
+
+        let result = webvh.resolve(
+            "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs?versionId=2-QmUCFFYYGBJhzZqyouAtvRJ7ULdd8FqSUvwb61FPTMH1Aj",
+            None,
+        ).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_reference_specific_time() {
+        let mut webvh = DIDWebVHState::default();
+
+        let result = webvh.resolve(
+            "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs?versionTime=2025-08-01T00:00:00Z",
+            None,
+        ).await;
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/resolve/ssi_resolve.rs
+++ b/src/resolve/ssi_resolve.rs
@@ -63,3 +63,49 @@ impl DIDMethodResolver for DIDWebVH {
 impl DIDMethod for DIDWebVH {
     const DID_METHOD_NAME: &'static str = "webvh";
 }
+
+#[cfg(test)]
+mod tests {
+    use ssi::dids::{DID, DIDResolver};
+
+    use crate::resolve::DIDWebVH;
+
+    #[tokio::test]
+    async fn resolve_reference() {
+        let webvh = DIDWebVH;
+
+        unsafe {
+            let result = webvh.resolve(
+            DID::new_unchecked("did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs".as_bytes()),
+        ).await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_reference_specific_version() {
+        let webvh = DIDWebVH;
+
+        unsafe {
+            let result = webvh.resolve(DID::new_unchecked(
+            "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs?versionId=2-QmUCFFYYGBJhzZqyouAtvRJ7ULdd8FqSUvwb61FPTMH1Aj".as_bytes()),
+        ).await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_reference_specific_time() {
+        let webvh = DIDWebVH;
+
+        unsafe {
+            let result = webvh.resolve(DID::new_unchecked(
+            "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs?versionTime=2025-08-01T00:00:00Z".as_bytes()),
+        ).await;
+
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/tests/first_log_entry.rs
+++ b/tests/first_log_entry.rs
@@ -14,18 +14,6 @@ fn test_first_log_entry_good() {
     assert!(first_log_entry.get_parameters().validate(None).is_ok());
 }
 
-#[ignore]
-#[test]
-fn test_first_log_entry_deactivated_error() {
-    let first_log_entry =
-        load_test_file("tests/test_vectors/first_log_entry_deactivated_error.jsonl");
-
-    let first_log_entry: LogEntry = LogEntry::deserialize_string(&first_log_entry, None)
-        .expect("Failed to parse first log entry JSON");
-
-    assert!(first_log_entry.get_parameters().validate(None).is_err());
-}
-
 #[test]
 fn test_first_log_entry_verify_signature() {
     let first_log_entry = load_test_file("tests/test_vectors/first_log_entry_verify_full.jsonl");


### PR DESCRIPTION
* **FIX:** [Issue #5](https://github.com/decentralized-identity/didwebvh-rs/issues/5)
UpdateKey not propagating to new LogEntry Parameter set when pre-rotation is disabled
  * Secondary issue of changing update-key also results in an error
* **FIX:** Wizard would not reset an existing did.jsonl file for a new DID
* **FIX:** Parameter method was always being placed in each LogEntry, will now
correctly skip if version is the same
