### PR TITLE
release 0.1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /*.jsonl
+/*.json
 /*-witness.json
 /*-secrets.json
 /www

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Release 0.1.6
 
-* **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
 * **IMPROVEMENT:** Wizard will now assist with exporting to did:web format
+  * The wizard will change DID Document values on your behalf
+  * It can also add to the did:webvh Document `alsoKnownAs` records
+* **IMPROVEMENT:** Resolver will now auto add implicit service records to the
+resolved DID Document where missing (#files and #whois)
 * **IMPROVEMENT:** DID Secrets now stored in the `did-secrets.json` when using the
 Wizard
 * **IMPROVEMENT:** Added X25519 key support for Encryption Keys (DID Doc)
+* **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
 
 ## 4th September 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Wizard
 * **IMPROVEMENT:** Added X25519 key support for Encryption Keys (DID Doc)
 * **IMPROVEMENT:** SSI Crate moved to a feature flag (`ssi`) so it becomes optional
 * **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
+* **FIX:** Wizard would exit with an error when aborting migrating the DID
+* **MAINTENANCE:** Updated crate dependencies
+* **MAINTENANCE:** Tests added for code coverage (@74.27% code coverage)
 
 ## 4th September 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # didwebvh-rs Changelog history
 
-## September 2025
+## 11th September 2025
 
 ### Release 0.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ resolved DID Document where missing (#files and #whois)
 * **IMPROVEMENT:** DID Secrets now stored in the `did-secrets.json` when using the
 Wizard
 * **IMPROVEMENT:** Added X25519 key support for Encryption Keys (DID Doc)
+* **IMPROVEMENT:** SSI Crate moved to a feature flag (`ssi`) so it becomes optional
 * **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
 
 ## 4th September 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # didwebvh-rs Changelog history
 
-## 4th  September 2025
+## September 2025
+
+### Release 0.1.6
+
+* **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
+* **IMPROVEMENT:** Wizard will now assist with exporting to did:web format
+* **IMPROVEMENT:** DID Secrets now stored in the `did-secrets.json` when using the
+Wizard
+* **IMPROVEMENT:** Added X25519 key support for Encryption Keys (DID Doc)
+
+## 4th September 2025
 
 ### Release 0.1.5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,16 +217,18 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b22f7eba2654e0c199270562620ef4c4a25e2b45aac9583aedd1911f285eed"
+checksum = "170b90e02e84db8f994b5a08fcebb30a60d98ec10a55f65843406dc2f329d35e"
 dependencies = [
  "ahash 0.8.12",
  "askar-crypto",
  "base58",
  "base64 0.22.1",
+ "ed25519-dalek",
  "multibase 0.9.1",
  "multihash 0.19.3",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c2a2b62d45b003b6a3afb2a5cec29aab99d01271b5756a358d05a2f1be9a40"
+checksum = "44ad26ac55172999da5beb5ecaab47c45e46c6afd2003dc447b3e4eed4efcd06"
 dependencies = [
  "affinidi-secrets-resolver",
  "chrono",
@@ -85,7 +85,6 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "ssi",
  "thiserror 2.0.16",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,16 +85,16 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tracing",
 ]
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57239f0b09cf8e969879844ec798429ffee719e82e74df9e820cfb4df6b8c65d"
+checksum = "b888fd11cb1cac7f010b328f7c41431ff3970bc07d13c8888c75dee1380ea44a"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -104,7 +104,7 @@ dependencies = [
  "reqwest 0.12.23",
  "serde",
  "serde_json",
- "ssi 0.11.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -131,7 +131,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha1",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -158,7 +158,7 @@ dependencies = [
  "reqwest 0.12.23",
  "serde",
  "serde_json",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tracing",
  "uuid",
@@ -182,7 +182,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha256",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -208,7 +208,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha256",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tokio-tungstenite",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab20acd2d015cf9313b42e2d66bd8d01a1c7d6111c81fdabc0fb9cb53eabfb9"
+checksum = "09b22f7eba2654e0c199270562620ef4c4a25e2b45aac9583aedd1911f285eed"
 dependencies = [
  "ahash 0.8.12",
  "askar-crypto",
@@ -231,17 +231,18 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "ssi 0.12.0",
+ "ssi-multicodec",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de3939261fc2d23d1de4ef35693800979711fab40f41721143fe7cb949244e"
+checksum = "b8e7100849225219b2700293808f33f0b1a9718eee86674bbbe4b9578e14436b"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-resolver-cache-sdk",
@@ -250,11 +251,12 @@ dependencies = [
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
+ "base64 0.22.1",
  "clap",
  "did-peer",
  "rustls 0.23.31",
  "serde_json",
- "ssi 0.11.0",
+ "ssi",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -323,12 +325,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -486,9 +482,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -496,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
 dependencies = [
  "bindgen",
  "cc",
@@ -572,25 +568,22 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.106",
- "which",
 ]
 
 [[package]]
@@ -954,17 +947,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1121,15 +1113,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1674,7 +1666,7 @@ dependencies = [
  "iref",
  "serde",
  "serde_json",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1756,7 +1748,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_with 3.14.0",
  "sha2 0.10.9",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1789,7 +1781,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_with 3.14.0",
  "sha2 0.10.9",
- "ssi 0.12.0",
+ "ssi",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1996,12 +1988,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2266,7 +2258,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2315,7 +2307,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2334,7 +2326,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2437,15 +2429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -2894,9 +2877,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2979,7 +2962,7 @@ dependencies = [
  "contextual",
  "educe 0.4.23",
  "futures",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-ld-context-processing",
  "json-ld-core",
@@ -3019,7 +3002,7 @@ dependencies = [
  "educe 0.4.23",
  "futures",
  "hashbrown 0.13.2",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-ld-syntax",
  "json-syntax",
@@ -3047,7 +3030,7 @@ dependencies = [
  "contextual",
  "educe 0.4.23",
  "futures",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-ld-context-processing",
  "json-ld-core",
@@ -3065,7 +3048,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "344f0a6042745d76a358b808878ae0d125a472de30b3eabc9eb82c6cf7f0c23e"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-ld-core",
  "json-syntax",
@@ -3085,7 +3068,7 @@ dependencies = [
  "decoded-char",
  "educe 0.4.23",
  "hashbrown 0.13.2",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-syntax",
  "langtag",
@@ -3205,12 +3188,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical"
@@ -3431,15 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -4217,7 +4188,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.31",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -4237,7 +4208,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
@@ -4378,7 +4349,7 @@ checksum = "4ccfa6b3af8f44db8d700038d47a9e8c8cc4126cdcafc069e82116903420631d"
 dependencies = [
  "contextual",
  "educe 0.5.11",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "langtag",
  "raw-btree",
@@ -4656,12 +4627,6 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4677,28 +4642,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4889,11 +4841,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5192,7 +5144,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5445,40 +5397,13 @@ dependencies = [
 
 [[package]]
 name = "ssi"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6094b897db914cc717b593afb0979e158e06052b65921ae78b6f8a3a572cfb8a"
-dependencies = [
- "document-features",
- "ssi-caips",
- "ssi-claims 0.3.0",
- "ssi-core",
- "ssi-crypto",
- "ssi-dids",
- "ssi-eip712",
- "ssi-json-ld",
- "ssi-jwk",
- "ssi-jws",
- "ssi-multicodec",
- "ssi-rdf",
- "ssi-security",
- "ssi-ssh",
- "ssi-status 0.4.0",
- "ssi-ucan",
- "ssi-verification-methods",
- "ssi-zcap-ld 0.4.0",
- "xsd-types",
-]
-
-[[package]]
-name = "ssi"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dfe4a37404b41134aaf775dd67f0b238344670f7fcbb8ed5a828e3a46c1988"
 dependencies = [
  "document-features",
  "ssi-caips",
- "ssi-claims 0.4.0",
+ "ssi-claims",
  "ssi-core",
  "ssi-crypto",
  "ssi-dids",
@@ -5490,10 +5415,10 @@ dependencies = [
  "ssi-rdf",
  "ssi-security",
  "ssi-ssh",
- "ssi-status 0.5.0",
+ "ssi-status",
  "ssi-ucan",
  "ssi-verification-methods",
- "ssi-zcap-ld 0.5.0",
+ "ssi-zcap-ld",
  "xsd-types",
 ]
 
@@ -5509,40 +5434,6 @@ dependencies = [
  "ssi-jwk",
  "thiserror 1.0.69",
  "xsd-types",
-]
-
-[[package]]
-name = "ssi-claims"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b65fc50341c4eb79e06da46456dd8eac68fc778419611f90d8db7ec4b7141b"
-dependencies = [
- "educe 0.4.23",
- "iref",
- "json-syntax",
- "linked-data",
- "locspan",
- "pin-project",
- "rdf-types",
- "serde",
- "serde_json",
- "ssi-claims-core",
- "ssi-core",
- "ssi-cose",
- "ssi-crypto",
- "ssi-data-integrity",
- "ssi-dids-core",
- "ssi-eip712",
- "ssi-json-ld",
- "ssi-jwk",
- "ssi-jws",
- "ssi-jwt",
- "ssi-sd-jwt",
- "ssi-security",
- "ssi-vc 0.5.0",
- "ssi-vc-jose-cose 0.3.0",
- "ssi-verification-methods",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5573,8 +5464,8 @@ dependencies = [
  "ssi-jwt",
  "ssi-sd-jwt",
  "ssi-security",
- "ssi-vc 0.6.1",
- "ssi-vc-jose-cose 0.4.0",
+ "ssi-vc",
+ "ssi-vc-jose-cose",
  "ssi-verification-methods",
  "thiserror 1.0.69",
 ]
@@ -5843,7 +5734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bd7124d707688e6f5b0f42537978b461d0f8871a7e9a703a1a6ea378b6ddbe"
 dependencies = [
  "hex",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "json-syntax",
  "keccak-hash",
@@ -5983,7 +5874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74d0aaccc80259913b4f2d456f2150ab2e8a4e8daf3b8edeaf527bb978e710b"
 dependencies = [
  "combination",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "iref",
  "linked-data",
  "rdf-types",
@@ -5998,7 +5889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5799e6fffa02065f2caf34735cb84dfac518248c937aade04cd17cd68fae5b45"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6038,36 +5929,6 @@ dependencies = [
 
 [[package]]
 name = "ssi-status"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eb723522b0ffb4f2609ed8656345b61a52e073d277296cd5e6b56a244f68d1"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "iref",
- "log",
- "multibase 0.9.1",
- "parking_lot",
- "rdf-types",
- "reqwest 0.12.23",
- "serde",
- "serde_json",
- "ssi-claims-core",
- "ssi-data-integrity",
- "ssi-json-ld",
- "ssi-jwk",
- "ssi-jws",
- "ssi-jwt",
- "ssi-sd-jwt",
- "ssi-vc 0.5.0",
- "ssi-vc-jose-cose 0.3.0",
- "ssi-verification-methods",
- "thiserror 1.0.69",
- "xsd-types",
-]
-
-[[package]]
-name = "ssi-status"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ff83ba78646497a8bcec0a8a8c406adaea4477c7db2d011039ba4c12fbc3ec"
@@ -6089,8 +5950,8 @@ dependencies = [
  "ssi-jws",
  "ssi-jwt",
  "ssi-sd-jwt",
- "ssi-vc 0.6.1",
- "ssi-vc-jose-cose 0.4.0",
+ "ssi-vc",
+ "ssi-vc-jose-cose",
  "ssi-verification-methods",
  "thiserror 1.0.69",
  "xsd-types",
@@ -6120,37 +5981,6 @@ dependencies = [
  "ssi-jwt",
  "ssi-verification-methods",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ssi-vc"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc096f9b205d0ff86e933780568cc414aba0d62a00acc01deb45c8d84bc28ba"
-dependencies = [
- "base64 0.22.1",
- "bitvec 0.20.4",
- "chrono",
- "educe 0.4.23",
- "flate2",
- "iref",
- "json-syntax",
- "linked-data",
- "rdf-types",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "ssi-claims-core",
- "ssi-core",
- "ssi-data-integrity",
- "ssi-dids-core",
- "ssi-json-ld",
- "ssi-jwt",
- "ssi-rdf",
- "ssi-verification-methods",
- "static-iref",
- "thiserror 1.0.69",
- "xsd-types",
 ]
 
 [[package]]
@@ -6186,27 +6016,6 @@ dependencies = [
 
 [[package]]
 name = "ssi-vc-jose-cose"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51a84ff6b8e2a768f7dc90330d7685b0cb166301316829d86b1c139ed7e8cc7"
-dependencies = [
- "base64 0.22.1",
- "ciborium",
- "serde",
- "serde_json",
- "ssi-claims-core",
- "ssi-cose",
- "ssi-json-ld",
- "ssi-jws",
- "ssi-jwt",
- "ssi-sd-jwt",
- "ssi-vc 0.5.0",
- "thiserror 1.0.69",
- "xsd-types",
-]
-
-[[package]]
-name = "ssi-vc-jose-cose"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50ab808a88436eb5fabeb526a35310cd1865296f72f48e770baacac5ea724302"
@@ -6221,7 +6030,7 @@ dependencies = [
  "ssi-jws",
  "ssi-jwt",
  "ssi-sd-jwt",
- "ssi-vc 0.6.1",
+ "ssi-vc",
  "thiserror 1.0.69",
  "xsd-types",
 ]
@@ -6293,30 +6102,6 @@ dependencies = [
 
 [[package]]
 name = "ssi-zcap-ld"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfc9d893b870efa42f5f6155dd2cf8aa75d56082e701f8e771291b81406cc82"
-dependencies = [
- "async-trait",
- "iref",
- "json-syntax",
- "rdf-types",
- "serde",
- "serde_json",
- "ssi-claims 0.3.0",
- "ssi-core",
- "ssi-dids-core",
- "ssi-eip712",
- "ssi-json-ld",
- "ssi-jwk",
- "ssi-rdf",
- "ssi-verification-methods",
- "static-iref",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ssi-zcap-ld"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24bf178587ab27c010e2a768c71eb1407491981b262bc004d5d8e6c55f674ac9"
@@ -6327,7 +6112,7 @@ dependencies = [
  "rdf-types",
  "serde",
  "serde_json",
- "ssi-claims 0.4.0",
+ "ssi-claims",
  "ssi-core",
  "ssi-dids-core",
  "ssi-eip712",
@@ -6516,15 +6301,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6751,7 +6536,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "toml_datetime",
  "winnow",
 ]
@@ -6933,9 +6718,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-width"
@@ -7095,9 +6880,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
@@ -7227,18 +7021,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,6 @@ dependencies = [
  "console",
  "dialoguer",
  "format_num",
- "iref",
  "multihash 0.19.3",
  "rand 0.9.2",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
  "did-peer",
- "didwebvh-rs 0.1.4",
+ "didwebvh-rs 0.1.5",
  "futures-util",
  "highway",
  "moka",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-meeting-place"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58b17c5e5257a48b123b31bcaee2917d4160944442b2a94521f231c4a267d7d"
+checksum = "631b8d70823a0618bdfa9e2fd3a9927cb5d8386bfc3ba61d08f3fd979ed86d7f"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-resolver-cache-sdk",
@@ -158,7 +158,7 @@ dependencies = [
  "reqwest 0.12.23",
  "serde",
  "serde_json",
- "ssi 0.11.0",
+ "ssi 0.12.0",
  "thiserror 2.0.16",
  "tracing",
  "uuid",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92ecfdca46b1f00b68c1ad0e1a755251e1e5230a86281cb2bf879d933bf7c45"
+checksum = "b7e8b8a0bb5a8e6d5635efc3075ca41d2a0a899a73cba4068a239774d2dd803a"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-secrets-resolver",
@@ -182,7 +182,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha256",
- "ssi 0.11.0",
+ "ssi 0.12.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec74f54851431a2c451777f9a80093103f5c84bcaa7392b40179e3cd90198ce5"
+checksum = "719d936e90a45b366fbaaa74905abdaec26deec747fd9e65af33a42d391edf38"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-messaging-didcomm",
@@ -208,7 +208,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha256",
- "ssi 0.11.0",
+ "ssi 0.12.0",
  "thiserror 2.0.16",
  "tokio",
  "tokio-tungstenite",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61bfc4022d7ff20ff255b7e48944693923ae8316c4b759f68ae503c06c87944"
+checksum = "fab20acd2d015cf9313b42e2d66bd8d01a1c7d6111c81fdabc0fb9cb53eabfb9"
 dependencies = [
  "ahash 0.8.12",
  "askar-crypto",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -964,7 +964,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "did-peer"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc129200b5a4d2c2ab6b9e1114ece7d83a77833a96ee6ba1bb07de299d6e9b6"
+checksum = "6397c8b2cfdede0ccd7b11237d28cd1e6f884c9ffddb1d6e0f9ff263137e7edf"
 dependencies = [
  "base64 0.22.1",
  "iref",
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d9ab3c90d0ccb99de3449d1050ad0f5e8121828aec966fac8d90590a06c91c"
+checksum = "ef2f789de3a1cf2fd2e3d92a34dfdf1e2e8f1b86eab64eaf30221b36fe3ec537"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -2048,9 +2048,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fixed-hash"
@@ -2265,7 +2265,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2940,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3181,7 +3181,7 @@ dependencies = [
  "dbus-secret-service",
  "log",
  "security-framework 2.11.1",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
  "windows-sys 0.60.2",
  "zeroize",
 ]
@@ -4737,7 +4737,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -4783,7 +4783,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.4",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -4804,7 +4804,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.4",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.2",
  "windows-sys 0.59.0",
@@ -4976,9 +4976,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
@@ -4989,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6702,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
@@ -6895,9 +6895,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -7094,30 +7094,31 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -7129,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7142,9 +7143,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7152,9 +7153,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7165,9 +7166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
@@ -7184,9 +7185,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7240,11 +7241,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7256,7 +7257,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -7277,7 +7278,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -7289,7 +7290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -7322,13 +7323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7337,7 +7344,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -7348,7 +7355,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7357,7 +7364,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7403,6 +7410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -7457,7 +7473,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7474,7 +7490,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7678,9 +7694,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -7761,18 +7777,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ dependencies = [
  "iref",
  "multihash 0.19.3",
  "rand 0.9.2",
+ "regex",
  "reqwest 0.12.23",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ license = "Apache-2.0"
 readme = "README.md"
 rust-version = "1.88.0"
 
+[features]
+default = []
+ssi = ["dep:ssi"]
+
 [dependencies]
 affinidi-data-integrity = "0.2"
 affinidi-secrets-resolver = "0.1"
@@ -28,9 +32,9 @@ serde_json = "1.0"
 serde_json_canonicalizer = "0.3.1"
 serde_with = "3.14"
 sha2 = "0.10"
-ssi = { version = "0.12", features = ["secp384r1"] }
+ssi = { version = "0.12", features = ["secp384r1"], optional = true }
 thiserror = "2.0"
-tokio = { version = "1.47", features = ["full"] }
+tokio = { version = "1.47" }
 tracing = { version = "0.1", features = [
   "max_level_debug",
   "release_max_level_info",
@@ -48,6 +52,7 @@ dialoguer = "0.12"
 format_num = "0.1.0"
 iref = { version = "3.2", features = ["serde"] }
 rand = "0.9"
+ssi = { version = "0.12", features = ["secp384r1"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.1.5"
+version = "0.1.6"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ affinidi-secrets-resolver = "0.1"
 ahash = { version = "0.8", features = ["serde"] }
 base58 = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
-iref = { version = "3.2", features = ["serde"] }
 multihash = "0.19"
 regex = "1.11"
 reqwest = "0.12"
@@ -50,9 +49,7 @@ clap = { version = "4.5", features = ["derive"] }
 console = "0.16"
 dialoguer = "0.12"
 format_num = "0.1.0"
-iref = { version = "3.2", features = ["serde"] }
 rand = "0.9"
-# ssi = { version = "0.12", features = ["secp384r1"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ dialoguer = "0.12"
 format_num = "0.1.0"
 iref = { version = "3.2", features = ["serde"] }
 rand = "0.9"
-ssi = { version = "0.12", features = ["secp384r1"] }
+# ssi = { version = "0.12", features = ["secp384r1"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ base58 = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 iref = { version = "3.2", features = ["serde"] }
 multihash = "0.19"
+regex = "1.11"
 reqwest = "0.12"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-didwebvh-rs = "0.1.5"
+didwebvh-rs = "0.1.6"
 ```
 
 Then:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ site
 - [x] Validate witness information
 - [x] DID Query Parameters versionId and versionTime implemented
 - [x] WebVH DID specification version support (v1.0 and pre-v1.0)
+- [x] Export WebVH to a did:web document
 
 ## Usage
 
@@ -48,6 +49,11 @@ let mut webvh = DIDWebVHState::default();
 // Load LogEntries from a file
 webvh.load_log_entries_from_file("did.jsonl")?;
 ```
+
+## Feature Flags
+
+- **ssi**
+  - Enables integration with the [ssi](https://crates.io/crates/ssi) crate
 
 ## Everyone likes a wizard
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 A complete implementation of the [did:webvh](https://identity.foundation/didwebvh/v1.0/)
 method in Rust. Supports version 1.0 spec.
 
-This library implements the [Rust SSI Library](https://github.com/spruceid/ssi)
-resolver traits for use in universal resolvers such as the [Affinidi DID resolver](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/affinidi-did-resolver)
-or your own.
-
 A helpful implementation site is the [webvh DID Method Information](https://didwebvh.info/)
 site
 
@@ -54,6 +50,7 @@ webvh.load_log_entries_from_file("did.jsonl")?;
 
 - **ssi**
   - Enables integration with the [ssi](https://crates.io/crates/ssi) crate
+    - This is useful when integrating into universal resolvers
 
 ## Everyone likes a wizard
 

--- a/examples/wizard/did_web.rs
+++ b/examples/wizard/did_web.rs
@@ -1,0 +1,97 @@
+use std::{fs::OpenOptions, io::Write};
+
+use console::style;
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use didwebvh_rs::{DIDWebVHError, DIDWebVHState, log_entry_state::LogEntryState};
+use serde_json::Value;
+
+// Checks to see if the did:web needs to be added to alsoKnownAs
+pub fn insert_also_known_as(did_document: &mut Value, did: &str) -> Result<(), DIDWebVHError> {
+    let did_web_id = DIDWebVHState::convert_webvh_id_to_web_id(did);
+
+    if Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!(
+            "Add ({did_web_id}) to alsoKnownAs for the did:webvh document?"
+        ))
+        .default(true)
+        .interact()
+        .unwrap()
+    {
+        let also_known_as = did_document.get_mut("alsoKnownAs");
+
+        let Some(also_known_as) = also_known_as else {
+            // There is no alsoKnownAs, add the did:web
+            did_document.as_object_mut().unwrap().insert(
+                "alsoKnownAs".to_string(),
+                Value::Array(vec![Value::String(did_web_id.to_string())]),
+            );
+            return Ok(());
+        };
+
+        let mut new_aliases = vec![];
+        let mut skip_flag = false;
+
+        if let Some(aliases) = also_known_as.as_array() {
+            for alias in aliases {
+                if let Some(alias_str) = alias.as_str() {
+                    if alias_str == did_web_id {
+                        // did:web already exists, skip it
+                        skip_flag = true;
+                    } else {
+                        new_aliases.push(alias.clone());
+                    }
+                }
+            }
+        } else {
+            return Err(DIDWebVHError::DIDError(
+                "alsoKnownAs is not an array".to_string(),
+            ));
+        }
+
+        if !skip_flag {
+            // web DID isn't an alias, add it
+            new_aliases.push(Value::String(did_web_id.to_string()));
+        }
+
+        did_document
+            .as_object_mut()
+            .unwrap()
+            .insert("alsoKnownAs".to_string(), Value::Array(new_aliases));
+    }
+    Ok(())
+}
+
+// Save a did:web document (did.json)
+pub fn save_did_web(log_entry: &LogEntryState) -> Result<(), DIDWebVHError> {
+    let did_web = log_entry.to_web_did()?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open("did.json")
+        .map_err(|e| DIDWebVHError::LogEntryError(format!("Couldn't open file (did.json): {e}")))?;
+
+    file.write_all(
+        serde_json::to_string_pretty(&did_web)
+            .map_err(|e| {
+                DIDWebVHError::LogEntryError(format!(
+                    "Couldn't serialize did:web Document to JSON. Reason: {e}",
+                ))
+            })?
+            .as_bytes(),
+    )
+    .map_err(|e| {
+        DIDWebVHError::LogEntryError(format!(
+            "Couldn't append LogEntry to file(did.json). Reason: {e}",
+        ))
+    })?;
+
+    println!(
+        "{} {}",
+        style("did:web saved to :").color256(69),
+        style("did.json").color256(214),
+    );
+
+    Ok(())
+}

--- a/examples/wizard/updating/mod.rs
+++ b/examples/wizard/updating/mod.rs
@@ -143,32 +143,32 @@ pub async fn edit_did() -> Result<()> {
             }
             1 => {
                 // DID Portability
-                migrate_did(&mut webvh_state, &mut config_info)?;
+                if migrate_did(&mut webvh_state, &mut config_info)? {
+                    let new_entry = webvh_state.log_entries.last().ok_or_else(|| {
+                        DIDWebVHError::LogEntryError("No new LogEntry created".to_string())
+                    })?;
 
-                let new_entry = webvh_state.log_entries.last().ok_or_else(|| {
-                    DIDWebVHError::LogEntryError("No new LogEntry created".to_string())
-                })?;
+                    let new_proofs = witness_log_entry(
+                        &mut webvh_state.witness_proofs,
+                        new_entry,
+                        &new_entry.get_active_witnesses(),
+                        &config_info,
+                    )?;
 
-                let new_proofs = witness_log_entry(
-                    &mut webvh_state.witness_proofs,
-                    new_entry,
-                    &new_entry.get_active_witnesses(),
-                    &config_info,
-                )?;
-
-                // Save info to files
-                new_entry.log_entry.save_to_file(&file_path)?;
-                config_info.save_to_file(&[file_name_prefix, "-secrets.json"].concat())?;
-                println!(
-                    "{}",
-                    style("Successfully created new LogEntry")
-                        .color256(34)
-                        .blink()
-                );
-                if new_proofs.is_some() {
-                    webvh_state
-                        .witness_proofs
-                        .save_to_file(&[file_name_prefix, "-witness.json"].concat())?;
+                    // Save info to files
+                    new_entry.log_entry.save_to_file(&file_path)?;
+                    config_info.save_to_file(&[file_name_prefix, "-secrets.json"].concat())?;
+                    println!(
+                        "{}",
+                        style("Successfully created new LogEntry")
+                            .color256(34)
+                            .blink()
+                    );
+                    if new_proofs.is_some() {
+                        webvh_state
+                            .witness_proofs
+                            .save_to_file(&[file_name_prefix, "-witness.json"].concat())?;
+                    }
                 }
 
                 break;

--- a/examples/wizard/updating/mod.rs
+++ b/examples/wizard/updating/mod.rs
@@ -2,7 +2,9 @@
 *   Tasks relating to editing an existing webvh DID go here
 */
 use crate::{
-    ConfigInfo, edit_did_document,
+    ConfigInfo,
+    did_web::save_did_web,
+    edit_did_document,
     updating::{
         authorization::update_authorization_keys, portable::migrate_did, revoke::revoke_did,
         watchers::modify_watcher_params, witness::modify_witness_params,
@@ -139,6 +141,16 @@ pub async fn edit_did() -> Result<()> {
                         .witness_proofs
                         .save_to_file(&[file_name_prefix, "-witness.json"].concat())?;
                 }
+
+                if Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Export latest state to a did:web document?")
+                    .default(true)
+                    .interact()
+                    .unwrap()
+                {
+                    save_did_web(new_entry)?;
+                }
+
                 break;
             }
             1 => {
@@ -168,6 +180,15 @@ pub async fn edit_did() -> Result<()> {
                         webvh_state
                             .witness_proofs
                             .save_to_file(&[file_name_prefix, "-witness.json"].concat())?;
+                    }
+
+                    if Confirm::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Export latest state to a did:web document?")
+                        .default(true)
+                        .interact()
+                        .unwrap()
+                    {
+                        save_did_web(new_entry)?;
                     }
                 }
 

--- a/examples/wizard/updating/portable.rs
+++ b/examples/wizard/updating/portable.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use url::Url;
 
 /// Revokes a webvh DID method
-pub fn migrate_did(didwebvh: &mut DIDWebVHState, secrets: &mut ConfigInfo) -> Result<()> {
+pub fn migrate_did(didwebvh: &mut DIDWebVHState, secrets: &mut ConfigInfo) -> Result<bool> {
     let Some(log_entry) = didwebvh.log_entries.last() else {
         bail!("There must at least be a first LogEntry for this DID to migrate it");
     };
@@ -68,7 +68,7 @@ pub fn migrate_did(didwebvh: &mut DIDWebVHState, secrets: &mut ConfigInfo) -> Re
         .default(true)
         .interact()?
     {
-        return Ok(());
+        return Ok(false);
     }
 
     // Modify the DID Doc and create new LogEntry
@@ -97,7 +97,7 @@ pub fn migrate_did(didwebvh: &mut DIDWebVHState, secrets: &mut ConfigInfo) -> Re
         .interact()?
     {
         println!("{}", style("Migration aborted!").color256(141));
-        return Ok(());
+        return Ok(false);
     }
 
     // Create new LogEntry for this migration
@@ -118,5 +118,5 @@ pub fn migrate_did(didwebvh: &mut DIDWebVHState, secrets: &mut ConfigInfo) -> Re
         .create_log_entry(None, &new_did_doc, &new_params, signing_key)
         .map_err(|e| anyhow!("Couldn't create LogEntry: {}", e))?;
 
-    Ok(())
+    Ok(true)
 }

--- a/src/did_web.rs
+++ b/src/did_web.rs
@@ -228,8 +228,16 @@ fn get_service_files(id: &str, url: &WebVHURL) -> Result<Value, DIDWebVHError> {
 #[cfg(test)]
 mod tests {
     use crate::{DIDWebVHState, did_web::to_web_did};
+    use serde::Deserialize;
     use serde_json::{Value, json};
-    use ssi::dids::document::{Service, service::Endpoint};
+
+    // Dummy struct to help with testing DID Services
+    #[derive(Deserialize, PartialEq)]
+    struct Service {
+        pub id: String,
+        #[serde(rename = "serviceEndpoint")]
+        pub service_endpoint: String,
+    }
 
     #[test]
     fn test_no_log_entry() {
@@ -365,32 +373,15 @@ mod tests {
         )
         .expect("Couldn't process service attribute");
 
-        let results: Vec<(String, String)> = services
-            .iter()
-            .map(|s| {
-                if let Endpoint::Uri(uri) = &s
-                    .service_endpoint
-                    .as_ref()
-                    .expect("Service Endpoint can't be empty")
-                    .first()
-                    .expect("Service Endpoint can't be Empty!")
-                {
-                    (s.id.to_string(), uri.to_string())
-                } else {
-                    panic!("Service Endpoint is not a URI");
-                }
-            })
-            .collect();
-
         assert_eq!(services.len(), 2);
-        assert!(results.contains(&(
-            "did:web:affinidi.com#files".to_string(),
-            "https://affinidi.com/".to_string()
-        )));
-        assert!(results.contains(&(
-            "did:web:affinidi.com#whois".to_string(),
-            "https://affinidi.com/whois.vp".to_string()
-        )));
+        assert!(services.contains(&Service {
+            id: "did:web:affinidi.com#files".to_string(),
+            service_endpoint: "https://affinidi.com/".to_string()
+        }));
+        assert!(services.contains(&Service {
+            id: "did:web:affinidi.com#whois".to_string(),
+            service_endpoint: "https://affinidi.com/whois.vp".to_string()
+        }));
     }
 
     #[test]
@@ -407,31 +398,14 @@ mod tests {
         )
         .expect("Couldn't process service attribute");
 
-        let results: Vec<(String, String)> = services
-            .iter()
-            .map(|s| {
-                if let Endpoint::Uri(uri) = &s
-                    .service_endpoint
-                    .as_ref()
-                    .expect("Service Endpoint can't be empty")
-                    .first()
-                    .expect("Service Endpoint can't be Empty!")
-                {
-                    (s.id.to_string(), uri.to_string())
-                } else {
-                    panic!("Service Endpoint is not a URI");
-                }
-            })
-            .collect();
-
         assert_eq!(services.len(), 2);
-        assert!(results.contains(&(
-            "did:web:affinidi.com:custom:path#files".to_string(),
-            "https://affinidi.com/custom/path/".to_string()
-        )));
-        assert!(results.contains(&(
-            "did:web:affinidi.com:custom:path#whois".to_string(),
-            "https://affinidi.com/custom/path/whois.vp".to_string()
-        )));
+        assert!(services.contains(&Service {
+            id: "did:web:affinidi.com:custom:path#files".to_string(),
+            service_endpoint: "https://affinidi.com/custom/path/".to_string()
+        }));
+        assert!(services.contains(&Service {
+            id: "did:web:affinidi.com:custom:path#whois".to_string(),
+            service_endpoint: "https://affinidi.com/custom/path/whois.vp".to_string()
+        }));
     }
 }

--- a/src/did_web.rs
+++ b/src/did_web.rs
@@ -1,0 +1,437 @@
+/*!
+*   Handles converting a WebVH DID to a Web DID Document
+*/
+
+use crate::{DIDWebVHError, DIDWebVHState, log_entry_state::LogEntryState, url::WebVHURL};
+use regex::Regex;
+use serde_json::{Value, json};
+
+impl DIDWebVHState {
+    /// Converts the last LogEntry to a DID Web Document
+    /// Will change the DID ID's as required
+    /// NOTE: You may still want to check the resulting DID Document for validity
+    pub fn to_web_did(&self) -> Result<Value, DIDWebVHError> {
+        if let Some(log_entry) = self.log_entries.last() {
+            log_entry.to_web_did()
+        } else {
+            // There is no Log Entry
+            Err(DIDWebVHError::NotFound)
+        }
+    }
+}
+
+impl LogEntryState {
+    /// Converts this LogEntry State to a DID Web Document
+    /// Converts the DID references automatically
+    /// NOTE: You may still want to check the resulting DID Document for validity
+    pub fn to_web_did(&self) -> Result<Value, DIDWebVHError> {
+        let state = self.get_state();
+        if !state.is_object() {
+            return Err(DIDWebVHError::DIDError(
+                "State is not a valid JSON Object".to_string(),
+            ));
+        }
+
+        to_web_did(state)
+    }
+}
+
+fn to_web_did(old_state: &Value) -> Result<Value, DIDWebVHError> {
+    let did_doc = serde_json::to_string(old_state)
+        .map_err(|e| DIDWebVHError::DIDError(format!("Couldn't serialize state: {}", e)))?;
+
+    // Replace the existing did:webvh:<SCID> with did:web
+    let re = Regex::new(r"(^did:webvh:[^:]+)")
+        .map_err(|e| DIDWebVHError::DIDError(format!("Couldn't create regex: {}", e)))?;
+    let new_did_doc = re.replace_all(&did_doc, "did:web");
+
+    let mut new_state: Value = serde_json::from_str(&new_did_doc)
+        .map_err(|e| DIDWebVHError::DIDError(format!("Couldn't parse new state: {}", e)))?;
+
+    // What is the new DID?
+    let (old_did, new_did) = if let Some(id) = old_state.get("id")
+        && let Some(id_str) = id.as_str()
+    {
+        // input: did:webvh:<SCID>:<path>
+        let parts: Vec<&str> = id_str.split(':').collect();
+        let mut new_did = String::new();
+        new_did.push_str("did:web");
+        for p in parts[3..].iter() {
+            new_did.push(':');
+            new_did.push_str(p);
+        }
+        (id_str.to_string(), new_did)
+    } else {
+        return Err(DIDWebVHError::DIDError(
+            "Couldn't find DID (id) attribute".to_string(),
+        ));
+    };
+
+    // Set the DID id
+    new_state
+        .as_object_mut()
+        .unwrap()
+        .insert("id".to_string(), Value::String(new_did.clone()));
+
+    // Reset the controller to be the webvh original ID
+    new_state
+        .as_object_mut()
+        .unwrap()
+        .insert("controller".to_string(), Value::String(old_did.clone()));
+
+    // Update alsoKnownAs
+    update_also_known_as(
+        old_state.get("alsoKnownAs"),
+        &mut new_state,
+        &old_did,
+        &new_did,
+    )?;
+
+    // Add implicit WebVH Services if not present
+    update_implicit_services(old_state.get("service"), &mut new_state, &old_did, &new_did)?;
+
+    Ok(new_state)
+}
+
+// Manages the updates to the alsoKnownAs DID attribute
+// Checks each entry, removes itself if it exists already
+// Adds the WebVH entry if it doesn't exist
+fn update_also_known_as(
+    also_known_as: Option<&Value>,
+    new_state: &mut Value,
+    old_did: &str,
+    new_did: &str,
+) -> Result<(), DIDWebVHError> {
+    let Some(also_known_as) = also_known_as else {
+        // There is no alsoKnownAs, add the old_did
+        new_state.as_object_mut().unwrap().insert(
+            "alsoKnownAs".to_string(),
+            Value::Array(vec![Value::String(old_did.to_string())]),
+        );
+        return Ok(());
+    };
+
+    let mut did_webvh_exists = false;
+    let mut new_aliases = vec![];
+
+    if let Some(aliases) = also_known_as.as_array() {
+        for alias in aliases {
+            if let Some(alias_str) = alias.as_str() {
+                if alias_str == new_did {
+                    // did:web already exists, skip it
+                } else if alias_str == old_did {
+                    // did:webvh already exists, add it
+                    did_webvh_exists = true;
+                    new_aliases.push(alias.clone());
+                } else {
+                    new_aliases.push(alias.clone());
+                }
+            }
+        }
+    } else {
+        return Err(DIDWebVHError::DIDError(
+            "alsoKnownAs is not an array".to_string(),
+        ));
+    }
+
+    if !did_webvh_exists {
+        // webvh DID isn't an alias, add it
+        new_aliases.push(Value::String(old_did.to_string()));
+    }
+
+    new_state
+        .as_object_mut()
+        .unwrap()
+        .insert("alsoKnownAs".to_string(), Value::Array(new_aliases));
+
+    Ok(())
+}
+
+// Checks and adds implicit services if not present (#files and #whois)
+fn update_implicit_services(
+    services: Option<&Value>,
+    new_state: &mut Value,
+    old_did: &str,
+    new_did: &str,
+) -> Result<(), DIDWebVHError> {
+    let url = WebVHURL::parse_did_url(old_did)?;
+
+    let Some(services) = services else {
+        // There are no services, add the implicit services
+        new_state.as_object_mut().unwrap().insert(
+            "service".to_string(),
+            Value::Array(vec![
+                get_service_whois(new_did, &url)?,
+                get_service_files(new_did, &url)?,
+            ]),
+        );
+        return Ok(());
+    };
+
+    if let Some(services) = services.as_array() {
+        let mut has_whois = false;
+        let mut has_files = false;
+
+        for service in services {
+            if let Some(id) = service.get("id").and_then(|v| v.as_str()) {
+                if id.ends_with("#whois") {
+                    has_whois = true;
+                } else if id.ends_with("#files") {
+                    has_files = true;
+                }
+            }
+        }
+
+        let mut new_services = services.clone();
+
+        if !has_whois {
+            new_services.push(get_service_whois(new_did, &url)?);
+        }
+        if !has_files {
+            new_services.push(get_service_files(new_did, &url)?);
+        }
+
+        new_state
+            .as_object_mut()
+            .unwrap()
+            .insert("service".to_string(), Value::Array(new_services));
+    } else {
+        return Err(DIDWebVHError::DIDError(
+            "services is not an array".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// id: did:web ID
+/// url: did:webvh URL
+fn get_service_whois(id: &str, url: &WebVHURL) -> Result<Value, DIDWebVHError> {
+    Ok(json!({
+        "@context": "https://identity.foundation/linked-vp/contexts/v1",
+        "id": ([id, "#whois"].concat()),
+        "type": "LinkedVerifiablePresentation",
+        "serviceEndpoint": url.get_http_whois_url()?
+    }))
+}
+
+/// id: did:web ID
+/// url: did:webvh URL
+fn get_service_files(id: &str, url: &WebVHURL) -> Result<Value, DIDWebVHError> {
+    Ok(json!({
+        "id": ([id,"#files"].concat()),
+        "type": "relativeRef",
+        "serviceEndpoint": url.get_http_files_url()?
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{DIDWebVHState, did_web::to_web_did};
+    use serde_json::{Value, json};
+    use ssi::dids::document::{Service, service::Endpoint};
+
+    #[test]
+    fn test_no_log_entry() {
+        let state = DIDWebVHState::default();
+
+        assert!(state.to_web_did().is_err());
+    }
+
+    #[test]
+    fn test_id_conversion() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com:path"});
+
+        let new_state = to_web_did(&old_state).expect("Couldn't convert to did:web");
+        assert_eq!(
+            new_state
+                .get("id")
+                .expect("Couldn't find (id)")
+                .as_str()
+                .expect("Expected a string for (id)"),
+            "did:web:affinidi.com:path"
+        );
+
+        assert_eq!(
+            new_state
+                .get("controller")
+                .expect("Couldn't find (controller)")
+                .as_str()
+                .expect("Expected a string for (controller)"),
+            "did:webvh:acme1234:affinidi.com:path"
+        );
+    }
+
+    #[test]
+    fn test_missing_id() {
+        let old_state = json!({"not_id": "did:webvh:acme1234:affinidi.com:path"});
+
+        assert!(to_web_did(&old_state).is_err());
+    }
+
+    #[test]
+    fn test_not_object() {
+        let old_state = Value::String("Not an object".to_string());
+
+        assert!(to_web_did(&old_state).is_err());
+    }
+
+    #[test]
+    fn test_also_known_as_empty() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com"});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let also_known_as: Vec<String> = serde_json::from_value(
+            did_web
+                .get("alsoKnownAs")
+                .expect("alsoKnownAs in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process alsoKnownAs attribute");
+
+        assert_eq!(also_known_as.len(), 1);
+        assert!(also_known_as.contains(&"did:webvh:acme1234:affinidi.com".to_string()));
+    }
+
+    #[test]
+    fn test_also_known_as_existing_webvh() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com", "alsoKnownAs": ["did:webvh:acme1234:affinidi.com"]});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let also_known_as: Vec<String> = serde_json::from_value(
+            did_web
+                .get("alsoKnownAs")
+                .expect("alsoKnownAs in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process alsoKnownAs attribute");
+
+        assert_eq!(also_known_as.len(), 1);
+        assert!(also_known_as.contains(&"did:webvh:acme1234:affinidi.com".to_string()));
+    }
+
+    #[test]
+    fn test_also_known_as_existing_web() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com", "alsoKnownAs": ["did:web:affinidi.com"]});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let also_known_as: Vec<String> = serde_json::from_value(
+            did_web
+                .get("alsoKnownAs")
+                .expect("alsoKnownAs in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process alsoKnownAs attribute");
+
+        assert_eq!(also_known_as.len(), 1);
+        assert!(!also_known_as.contains(&"did:web:affinidi.com".to_string()));
+        assert!(also_known_as.contains(&"did:webvh:acme1234:affinidi.com".to_string()));
+    }
+
+    #[test]
+    fn test_also_known_as_existing_many() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com", "alsoKnownAs": ["did:web:affinidi.com", "did:webvh:acme1234:affinidi.com", "did:web:unknown.com"]});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let also_known_as: Vec<String> = serde_json::from_value(
+            did_web
+                .get("alsoKnownAs")
+                .expect("alsoKnownAs in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process alsoKnownAs attribute");
+
+        assert_eq!(also_known_as.len(), 2);
+        assert!(!also_known_as.contains(&"did:web:affinidi.com".to_string()));
+        assert!(also_known_as.contains(&"did:web:unknown.com".to_string()));
+        assert!(also_known_as.contains(&"did:webvh:acme1234:affinidi.com".to_string()));
+    }
+
+    #[test]
+    fn test_services_none() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com"});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let services: Vec<Service> = serde_json::from_value(
+            did_web
+                .get("service")
+                .expect("service in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process service attribute");
+
+        let results: Vec<(String, String)> = services
+            .iter()
+            .map(|s| {
+                if let Endpoint::Uri(uri) = &s
+                    .service_endpoint
+                    .as_ref()
+                    .expect("Service Endpoint can't be empty")
+                    .first()
+                    .expect("Service Endpoint can't be Empty!")
+                {
+                    (s.id.to_string(), uri.to_string())
+                } else {
+                    panic!("Service Endpoint is not a URI");
+                }
+            })
+            .collect();
+
+        assert_eq!(services.len(), 2);
+        assert!(results.contains(&(
+            "did:web:affinidi.com#files".to_string(),
+            "https://affinidi.com/".to_string()
+        )));
+        assert!(results.contains(&(
+            "did:web:affinidi.com#whois".to_string(),
+            "https://affinidi.com/whois.vp".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_services_none_custom_path() {
+        let old_state = json!({"id": "did:webvh:acme1234:affinidi.com:custom:path"});
+
+        let did_web = to_web_did(&old_state).expect("Couldn't convert to did:web");
+
+        let services: Vec<Service> = serde_json::from_value(
+            did_web
+                .get("service")
+                .expect("service in did:web doesn't exist")
+                .to_owned(),
+        )
+        .expect("Couldn't process service attribute");
+
+        let results: Vec<(String, String)> = services
+            .iter()
+            .map(|s| {
+                if let Endpoint::Uri(uri) = &s
+                    .service_endpoint
+                    .as_ref()
+                    .expect("Service Endpoint can't be empty")
+                    .first()
+                    .expect("Service Endpoint can't be Empty!")
+                {
+                    (s.id.to_string(), uri.to_string())
+                } else {
+                    panic!("Service Endpoint is not a URI");
+                }
+            })
+            .collect();
+
+        assert_eq!(services.len(), 2);
+        assert!(results.contains(&(
+            "did:web:affinidi.com:custom:path#files".to_string(),
+            "https://affinidi.com/custom/path/".to_string()
+        )));
+        assert!(results.contains(&(
+            "did:web:affinidi.com:custom:path#whois".to_string(),
+            "https://affinidi.com/custom/path/whois.vp".to_string()
+        )));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,6 @@ mod tests {
     use affinidi_secrets_resolver::secrets::Secret;
     use chrono::Utc;
     use serde_json::Value;
-    use ssi::JWK;
     use std::sync::Arc;
 
     fn did_doc() -> Value {
@@ -534,8 +533,7 @@ mod tests {
 
     #[test]
     fn webvh_create_log_entry() {
-        let key = Secret::from_jwk(&JWK::generate_ed25519().unwrap())
-            .expect("Couldn't create signing key");
+        let key = Secret::generate_ed25519(None);
 
         let state = did_doc();
 
@@ -555,8 +553,7 @@ mod tests {
 
     #[test]
     fn webvh_create_log_entry_no_update_keys() {
-        let key = Secret::from_jwk(&JWK::generate_ed25519().unwrap())
-            .expect("Couldn't create signing key");
+        let key = Secret::generate_ed25519(None);
 
         let state = did_doc();
 
@@ -573,8 +570,8 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_no_previous() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
+
         let result = DIDWebVHState::check_signing_key(
             None,
             &Parameters {
@@ -593,8 +590,8 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_no_previous_error() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
+
         let result = DIDWebVHState::check_signing_key(
             None,
             &Parameters {
@@ -609,8 +606,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_with_previous() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),
@@ -648,8 +644,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_with_previous_error() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),
@@ -683,8 +678,8 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_pre_rotate_no_previous() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
+
         let result = DIDWebVHState::check_signing_key(
             None,
             &Parameters {
@@ -708,11 +703,9 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_pre_rotate_previous() {
-        let secret = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let secret = Secret::generate_ed25519(None);
 
-        let next = Secret::from_jwk(&JWK::generate_ed25519().expect("Couldn't create Secret"))
-            .expect("Couldn't create Secret");
+        let next = Secret::generate_ed25519(None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::{fmt, sync::Arc};
 use thiserror::Error;
 use tracing::debug;
 
+pub mod did_web;
 pub mod log_entry;
 pub mod log_entry_state;
 pub mod parameters;

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -21,6 +21,7 @@ use tracing::{Instrument, Level, span, warn};
 use url::Url;
 
 /// Integration with the Spruice ID SSI Library
+#[cfg(feature = "ssi")]
 pub mod ssi_resolve;
 
 pub struct DIDWebVH;


### PR DESCRIPTION
* **IMPROVEMENT:** Wizard will now assist with exporting to did:web format
  * The wizard will change DID Document values on your behalf
  * It can also add to the did:webvh Document `alsoKnownAs` records
* **IMPROVEMENT:** Resolver will now auto add implicit service records to the
resolved DID Document where missing (#files and #whois)
* **IMPROVEMENT:** DID Secrets now stored in the `did-secrets.json` when using the
Wizard
* **IMPROVEMENT:** Added X25519 key support for Encryption Keys (DID Doc)
* **IMPROVEMENT:** SSI Crate moved to a feature flag (`ssi`) so it becomes optional
* **FIX:** URL parsing would incorrectly handle trailing slashes on URL Path
* **FIX:** Wizard would exit with an error when aborting migrating the DID
* **MAINTENANCE:** Updated crate dependencies
* **MAINTENANCE:** Tests added for code coverage (@74.27% code coverage)
