### PR TITLE
Disable `max_level_debug` and `release_max_level_info` features in tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,7 @@ sha2 = "0.10"
 ssi = { version = "0.12", features = ["secp384r1"], optional = true }
 thiserror = "2.0"
 tokio = { version = "1.47" }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }
 url = "2.5"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 


### PR DESCRIPTION
As this crate is meant as a library and not as a binary, enabling the `max_level_debug` and `release_max_level_info` features in `tracing` does not seem right to me. It causes dependent binaries to have at most debug or info logs enabled, respectively, without a way to circumvent this. In other words, I think, only the resulting binary should set those feature flags.