### PR TITLE
release 0.1.10 of webvh implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Release 0.1.10
 
+- **FEATURE:** Added the wizard the ability to easily add a did:scid:vh alsoKnownAs
+  alias
+  - This matches with making WebVH as reusable as possible, supporting did:web and
+    did:scid in parallel
 - **MAINTENANCE:** Updated `affinidi-secrets-resolver` to 0.4.x release
+- **MAINTENANCE:** Updated `affinidi-data-integrity` to 0.3.x release
+- **MAINTENANCE:** Updated downstream dependencies
 
 ## 3rd October 2025
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 ssi = ["dep:ssi"]
 
 [dependencies]
-affinidi-data-integrity = "0.2"
+affinidi-data-integrity = "0.3"
 affinidi-secrets-resolver = "0.4"
 
 ahash = { version = "0.8", features = ["serde"] }
@@ -29,7 +29,7 @@ reqwest = "0.12"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_json_canonicalizer = "0.3.1"
-serde_with = "3.15"
+serde_with = "3.16"
 sha2 = "0.10"
 ssi = { version = "0.12", features = ["secp384r1"], optional = true }
 thiserror = "2.0"
@@ -42,7 +42,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 affinidi-tdk = "0.2"
 
 anyhow = "1.0"
-byte-unit = "5.1"
+byte-unit = "5.2"
 clap = { version = "4.5", features = ["derive"] }
 console = "0.16"
 dialoguer = "0.12"

--- a/examples/generate_history.rs
+++ b/examples/generate_history.rs
@@ -508,7 +508,7 @@ async fn create_log_entry(
     }
 
     // Swap a watcher node?
-    if count % 6 == 0 {
+    if count.is_multiple_of(6) {
         swap_watcher(&mut new_params)?;
     }
 

--- a/examples/wizard/did_scid.rs
+++ b/examples/wizard/did_scid.rs
@@ -1,0 +1,59 @@
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use didwebvh_rs::{DIDWebVHError, DIDWebVHState};
+use serde_json::Value;
+
+// Adds a did:scid:vh:1:.. aslias to alsoKnownAs
+pub fn insert_scid_also_known_as(did_document: &mut Value, did: &str) -> Result<(), DIDWebVHError> {
+    let did_scid_id = DIDWebVHState::convert_webvh_id_to_scid_id(did);
+
+    if Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!(
+            "Add ({did_scid_id}) to alsoKnownAs for the did:webvh document?"
+        ))
+        .default(true)
+        .interact()
+        .unwrap()
+    {
+        let also_known_as = did_document.get_mut("alsoKnownAs");
+
+        let Some(also_known_as) = also_known_as else {
+            // There is no alsoKnownAs, add the did:web
+            did_document.as_object_mut().unwrap().insert(
+                "alsoKnownAs".to_string(),
+                Value::Array(vec![Value::String(did_scid_id.to_string())]),
+            );
+            return Ok(());
+        };
+
+        let mut new_aliases = vec![];
+        let mut skip_flag = false;
+
+        if let Some(aliases) = also_known_as.as_array() {
+            for alias in aliases {
+                if let Some(alias_str) = alias.as_str() {
+                    if alias_str == did_scid_id {
+                        // did:web already exists, skip it
+                        skip_flag = true;
+                    } else {
+                        new_aliases.push(alias.clone());
+                    }
+                }
+            }
+        } else {
+            return Err(DIDWebVHError::DIDError(
+                "alsoKnownAs is not an array".to_string(),
+            ));
+        }
+
+        if !skip_flag {
+            // web DID isn't an alias, add it
+            new_aliases.push(Value::String(did_scid_id.to_string()));
+        }
+
+        did_document
+            .as_object_mut()
+            .unwrap()
+            .insert("alsoKnownAs".to_string(), Value::Array(new_aliases));
+    }
+    Ok(())
+}

--- a/examples/wizard/did_web.rs
+++ b/examples/wizard/did_web.rs
@@ -1,12 +1,11 @@
-use std::{fs::OpenOptions, io::Write};
-
 use console::style;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use didwebvh_rs::{DIDWebVHError, DIDWebVHState, log_entry_state::LogEntryState};
 use serde_json::Value;
+use std::{fs::OpenOptions, io::Write};
 
 // Checks to see if the did:web needs to be added to alsoKnownAs
-pub fn insert_also_known_as(did_document: &mut Value, did: &str) -> Result<(), DIDWebVHError> {
+pub fn insert_web_also_known_as(did_document: &mut Value, did: &str) -> Result<(), DIDWebVHError> {
     let did_web_id = DIDWebVHState::convert_webvh_id_to_web_id(did);
 
     if Confirm::with_theme(&ColorfulTheme::default())

--- a/src/did_web.rs
+++ b/src/did_web.rs
@@ -21,7 +21,7 @@ impl DIDWebVHState {
             Err(DIDWebVHError::NotFound)
         }
     }
-    ///
+
     /// Takes a did:webvh ID and converts it to a did:web ID
     pub fn convert_webvh_id_to_web_id(id: &str) -> String {
         // input: did:webvh:<SCID>:<path>
@@ -31,6 +31,22 @@ impl DIDWebVHState {
         for p in parts[3..].iter() {
             new_did.push(':');
             new_did.push_str(p);
+        }
+        new_did
+    }
+
+    /// Takes a did:webvh ID and converts it to a did:scid:vh ID
+    pub fn convert_webvh_id_to_scid_id(id: &str) -> String {
+        // input: did:webvh:<SCID>:<path>
+        let mut new_did = String::new();
+        new_did.push_str("did:scid:vh:1:");
+        let re = Regex::new(r"^did:webvh:([^:]*):(.*)$").unwrap();
+        if let Some(captures) = re.captures(id) {
+            new_did.push_str(captures.get(1).unwrap().as_str()); // scid
+            new_did.push_str("?src=");
+            if let Some(path) = captures.get(2) {
+                new_did.push_str(&path.as_str().replace(":", "/"));
+            }
         }
         new_did
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,7 @@ mod tests {
 
     #[test]
     fn webvh_create_log_entry() {
-        let key = Secret::generate_ed25519(None);
+        let key = Secret::generate_ed25519(None, None);
 
         let state = did_doc();
 
@@ -553,7 +553,7 @@ mod tests {
 
     #[test]
     fn webvh_create_log_entry_no_update_keys() {
-        let key = Secret::generate_ed25519(None);
+        let key = Secret::generate_ed25519(None, None);
 
         let state = did_doc();
 
@@ -570,7 +570,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_no_previous() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
         let result = DIDWebVHState::check_signing_key(
             None,
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_no_previous_error() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
         let result = DIDWebVHState::check_signing_key(
             None,
@@ -606,7 +606,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_with_previous() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),
@@ -644,7 +644,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_no_pre_rotate_with_previous_error() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_pre_rotate_no_previous() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
         let result = DIDWebVHState::check_signing_key(
             None,
@@ -703,9 +703,9 @@ mod tests {
 
     #[test]
     fn webvh_check_signing_key_pre_rotate_previous() {
-        let secret = Secret::generate_ed25519(None);
+        let secret = Secret::generate_ed25519(None, None);
 
-        let next = Secret::generate_ed25519(None);
+        let next = Secret::generate_ed25519(None, None);
 
         let parameters = Parameters {
             scid: Some(Arc::new("1-abcdef1234567890".to_string())),

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -5,10 +5,10 @@
 use super::LogEntry;
 use crate::{
     DIDWebVHError, SCID_HOLDER,
-    log_entry::{LogEntryMethods, spec_1_0::LogEntry1_0, spec_1_0_pre::LogEntry1_0Pre},
+    log_entry::{LogEntryMethods, PublicKey, spec_1_0::LogEntry1_0, spec_1_0_pre::LogEntry1_0Pre},
     parameters::Parameters,
 };
-use affinidi_data_integrity::verification_proof::verify_data;
+use affinidi_data_integrity::verification_proof::verify_data_with_public_key;
 use chrono::Utc;
 use std::{
     fs::File,
@@ -102,9 +102,13 @@ impl LogEntry {
             }),
         };
 
-        let verified = verify_data(&verify_doc, None, proof).map_err(|e| {
-            DIDWebVHError::LogEntryError(format!("Signature verification failed: {e}"))
-        })?;
+        let verified = verify_data_with_public_key(
+            &verify_doc,
+            None,
+            proof,
+            proof.get_public_key_bytes()?.as_slice(),
+        )
+        .map_err(|e| DIDWebVHError::LogEntryError(format!("Signature verification failed: {e}")))?;
         if !verified.verified {
             return Err(DIDWebVHError::LogEntryError(
                 "Signature verification failed".to_string(),

--- a/src/log_entry/spec_1_0.rs
+++ b/src/log_entry/spec_1_0.rs
@@ -1,6 +1,8 @@
 //! WebVH Specification 1.0 implementation
 
-use affinidi_data_integrity::{DataIntegrityProof, verification_proof::verify_data};
+use affinidi_data_integrity::{
+    DataIntegrityProof, verification_proof::verify_data_with_public_key,
+};
 use base58::ToBase58;
 use chrono::{DateTime, FixedOffset};
 use multihash::Multihash;
@@ -12,7 +14,7 @@ use tracing::debug;
 
 use crate::{
     DIDWebVHError,
-    log_entry::{LogEntry, LogEntryCreate, LogEntryMethods},
+    log_entry::{LogEntry, LogEntryCreate, LogEntryMethods, PublicKey},
     parameters::{Parameters, spec_1_0::Parameters1_0},
     resolve::implicit::update_implicit_services,
 };
@@ -71,7 +73,13 @@ impl LogEntry1_0 {
         witness_proof: &DataIntegrityProof,
     ) -> Result<bool, DIDWebVHError> {
         // Verify the Data Integrity Proof against the Signing Document
-        verify_data(&json!({"versionId": &self.version_id}), None, witness_proof).map_err(|e| {
+        verify_data_with_public_key(
+            &json!({"versionId": &self.version_id}),
+            None,
+            witness_proof,
+            witness_proof.get_public_key_bytes()?.as_slice(),
+        )
+        .map_err(|e| {
             DIDWebVHError::LogEntryError(format!("Data Integrity Proof verification failed: {e}"))
         })?;
 

--- a/src/log_entry/spec_1_0_pre.rs
+++ b/src/log_entry/spec_1_0_pre.rs
@@ -2,7 +2,9 @@
 //! This exists as there was a period of time where some LogEntries
 //! for version 1.0 may contain nulls instead of empty arrays
 
-use affinidi_data_integrity::{DataIntegrityProof, verification_proof::verify_data};
+use affinidi_data_integrity::{
+    DataIntegrityProof, verification_proof::verify_data_with_public_key,
+};
 use base58::ToBase58;
 use chrono::{DateTime, FixedOffset};
 use multihash::Multihash;
@@ -14,7 +16,7 @@ use tracing::debug;
 
 use crate::{
     DIDWebVHError,
-    log_entry::{LogEntry, LogEntryCreate, LogEntryMethods},
+    log_entry::{LogEntry, LogEntryCreate, LogEntryMethods, PublicKey},
     parameters::{Parameters, spec_1_0_pre::Parameters1_0Pre},
     resolve::implicit::update_implicit_services,
 };
@@ -73,7 +75,13 @@ impl LogEntry1_0Pre {
         witness_proof: &DataIntegrityProof,
     ) -> Result<bool, DIDWebVHError> {
         // Verify the Data Integrity Proof against the Signing Document
-        verify_data(&json!({"versionId": &self.version_id}), None, witness_proof).map_err(|e| {
+        verify_data_with_public_key(
+            &json!({"versionId": &self.version_id}),
+            None,
+            witness_proof,
+            witness_proof.get_public_key_bytes()?.as_slice(),
+        )
+        .map_err(|e| {
             DIDWebVHError::LogEntryError(format!("Data Integrity Proof verification failed: {e}"))
         })?;
 

--- a/tests/first_log_entry.rs
+++ b/tests/first_log_entry.rs
@@ -1,5 +1,5 @@
-use affinidi_data_integrity::verification_proof::verify_data;
-use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+use affinidi_data_integrity::verification_proof::verify_data_with_public_key;
+use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods, PublicKey};
 
 #[cfg(test)]
 pub fn load_test_file(file: &str) -> String {
@@ -33,7 +33,15 @@ fn test_first_log_entry_verify_signature() {
 
     first_log_entry.clear_proofs();
 
-    assert!(verify_data(&first_log_entry, None, &proof).is_ok());
+    assert!(
+        verify_data_with_public_key(
+            &first_log_entry,
+            None,
+            &proof,
+            proof.get_public_key_bytes().unwrap().as_slice()
+        )
+        .is_ok()
+    );
 }
 
 #[test]
@@ -52,7 +60,15 @@ fn test_first_log_entry_verify_signature_tampered() {
 
     first_log_entry.clear_proofs();
 
-    assert!(verify_data(&first_log_entry, None, &proof).is_err());
+    assert!(
+        verify_data_with_public_key(
+            &first_log_entry,
+            None,
+            &proof,
+            proof.get_public_key_bytes().unwrap().as_slice()
+        )
+        .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Release 0.1.10

- **FEATURE:** Added the wizard the ability to easily add a did:scid:vh alsoKnownAs
  alias
  - This matches with making WebVH as reusable as possible, supporting did:web and
    did:scid in parallel
- **MAINTENANCE:** Updated `affinidi-secrets-resolver` to 0.4.x release
- **MAINTENANCE:** Updated `affinidi-data-integrity` to 0.3.x release
- **MAINTENANCE:** Updated downstream dependencies