### PR TITLE
chore: trim keywords and bump clap dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 authors = ["Glenn Gore <glenn@affinidi.com>"]
 homepage = "https://didwebvh.info/"
 categories = ["authentication", "cryptography", "web-programming"]
-keywords = ["ssi", "did", "decentralized-identity", "webvh", "verifiable"]
+keywords = ["ssi", "did", "webvh", "verifiable"]
 publish = true
 license = "Apache-2.0"
 readme = "README.md"
@@ -46,7 +46,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 affinidi-tdk = "0.6"
 anyhow = "1.0"
 byte-unit = "5.2"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 console = "0.16"
 dialoguer = "0.12"
 format_num = "0.1.0"


### PR DESCRIPTION
Remove "decentralized-identity" keyword (crates.io allows max 5, and it's less discoverable than the others) and bump clap from 4.5 to 4.6.