### PR TITLE
feat: add HTTP response size limits to DID resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # didwebvh-rs Changelog history
 
+## 27th March 2026
+
+### Release 0.4.0
+
+#### Breaking Changes
+
+- **`resolve()` / `resolve_owned()` signature change** — The `timeout` and
+  `eager_witness_download` parameters have been replaced with a single
+  `ResolveOptions` struct. Callers should migrate from
+  `resolve(did, None, false)` to `resolve(did, ResolveOptions::default())`.
+  Custom timeout or eager witness download can be set via struct fields:
+  ```rust
+  ResolveOptions {
+      timeout: Some(Duration::from_secs(5)),
+      eager_witness_download: true,
+      ..ResolveOptions::default()
+  }
+  ```
+
+#### New
+
+- **HTTP response size limits** — `download_file()` now enforces a maximum
+  response body size to prevent memory exhaustion from malicious or
+  misconfigured servers.
+  - `Content-Length` header is checked first for early rejection before any
+    body data is read.
+  - Body is read in chunks via `response.chunk()` with a running byte counter,
+    catching oversized responses even when `Content-Length` is absent or
+    inaccurate (e.g. chunked transfer encoding).
+  - Default limit: 200 KB (`DEFAULT_MAX_RESPONSE_BYTES`), configurable
+    per-request via `ResolveOptions::max_response_bytes`.
+- **`ResolveOptions` struct** — Bundles network resolution options (`timeout`,
+  `eager_witness_download`, `max_response_bytes`) into a single configuration
+  type with sensible defaults via `Default` trait. Re-exported from `prelude`
+  behind the `network` feature gate.
+- **`ResponseTooLarge` error variant** — New `DIDWebVHError::ResponseTooLarge`
+  carries the offending URL and the configured byte limit, making it easy for
+  consumers to distinguish size-limit rejections from other network errors.
+- **`generate_large_did` example** — Generates a valid 1 MB+ `did.jsonl` file
+  with backdated timestamps for benchmarking and testing. Accepts a URL via
+  `--url` (properly parsed into WebVH DID format via `WebVHURL::parse_url()`),
+  configurable target size (`--target-kb`), and includes generation, write, load,
+  and validation timing.
+- **`resolve` example CLI improvements** — Now uses `clap` for argument parsing
+  with a `--max-size-kb` (`-l`) flag to set the response size limit from the
+  command line.
+
 ## 19th March 2026
 
 ### Release 0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.3.1"
+version = "0.4.0"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_json_canonicalizer = "0.3"
 serde_with = "3.18"
-sha2 = "0.10"
+sha2 = "0.11"
 ssi = { version = "0.15", features = ["secp384r1"], optional = true }
 thiserror = "2.0"
 tokio = { version = "1.50" }
@@ -72,6 +72,10 @@ required-features = ["network"]
 
 [[example]]
 name = "generate_history"
+required-features = ["network"]
+
+[[example]]
+name = "generate_large_did"
 required-features = ["network"]
 
 [[bench]]

--- a/examples/generate_large_did.rs
+++ b/examples/generate_large_did.rs
@@ -1,0 +1,393 @@
+//! Generate a large (1 MB+) WebVH DID file
+//!
+//! Creates a valid did.jsonl with enough log entries to exceed 1 MB, using
+//! backdated timestamps so the file passes verification. Each update rotates
+//! keys and adds service endpoints to bulk up the DID document.
+//!
+//! Usage:
+//!   cargo run --example generate_large_did -- --url https://example.com
+//!   cargo run --example generate_large_did -- --url https://example.com:8080/custom/path
+//!   cargo run --example generate_large_did -- --url https://example.com --target-kb 2048
+
+use affinidi_secrets_resolver::{SecretsResolver, SimpleSecretsResolver, secrets::Secret};
+use affinidi_tdk::dids::{DID, KeyType};
+use anyhow::{Result, anyhow};
+use byte_unit::{Byte, UnitType};
+use chrono::{Duration as ChronoDuration, FixedOffset, Utc};
+use clap::Parser;
+use console::style;
+use didwebvh_rs::{DIDWebVHState, Multibase, parameters::Parameters, url::WebVHURL};
+use serde_json::json;
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    sync::Arc,
+    time::SystemTime,
+};
+use tracing_subscriber::filter;
+
+#[derive(Parser, Debug)]
+#[command(version, about = "Generate a large (1 MB+) WebVH DID file")]
+struct Args {
+    /// URL for the DID (e.g. "https://example.com" or "https://example.com:8080/custom/path")
+    #[arg(short, long)]
+    url: String,
+
+    /// Target file size in KB (default: 1024 = 1 MB)
+    #[arg(short, long, default_value_t = 1024)]
+    target_kb: u64,
+
+    /// Number of service endpoints per DID document (bulks up each entry)
+    #[arg(short, long, default_value_t = 5)]
+    services: usize,
+}
+
+#[tokio::main]
+pub async fn main() -> Result<()> {
+    let args: Args = Args::parse();
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter::EnvFilter::from_default_env())
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
+
+    let target_bytes = args.target_kb * 1024;
+
+    // Parse the URL into a WebVHURL to properly derive the DID template
+    let parsed_url = url::Url::parse(&args.url)
+        .map_err(|e| anyhow!("Invalid URL '{}': {e}", args.url))?;
+    let webvh_url = WebVHURL::parse_url(&parsed_url)
+        .map_err(|e| anyhow!("Cannot convert URL to WebVH DID: {e}"))?;
+    // to_did_base() produces "did:webvh:{SCID}:domain%3Aport:path" with proper encoding
+    let did_template = webvh_url.to_did_base();
+
+    println!(
+        "{}{}{}{}{}{}{} ",
+        style("Generate Large DID: target ").color256(34),
+        style(format!("{} KB", args.target_kb)).color256(69),
+        style(", URL: ").color256(34),
+        style(&args.url).color256(69),
+        style(", services per doc: ").color256(34),
+        style(args.services).color256(69),
+        style(")").color256(34),
+    );
+    println!(
+        "\t{}{}",
+        style("DID template: ").color256(34),
+        style(&did_template).color256(69),
+    );
+
+    let mut didwebvh = DIDWebVHState::default();
+    let mut secrets = SimpleSecretsResolver::new(&[]).await;
+
+    // Estimate entries needed (we'll keep going until we hit target size)
+    // Use a base time far enough in the past to accommodate many entries
+    let estimated_entries = (target_bytes / 800).max(1500) as i64;
+    let base_time = (Utc::now() - ChronoDuration::seconds(estimated_entries + 10)).fixed_offset();
+
+    // === Generate initial DID ===
+    let gen_start = SystemTime::now();
+
+    let (signing_key, next_keys) = generate_keys(&mut secrets).await?;
+
+    let did_document = build_did_document(&did_template, &signing_key, args.services)?;
+
+    let params = Parameters::new()
+        .with_portable(true)
+        .with_update_keys(vec![signing_key.get_public_keymultibase()?])
+        .with_next_key_hashes(vec![
+            next_keys[0].get_public_keymultibase_hash()?,
+            next_keys[1].get_public_keymultibase_hash()?,
+        ])
+        .with_ttl(3600)
+        .build();
+
+    didwebvh
+        .create_log_entry(Some(base_time), &did_document, &params, &signing_key)
+        .await?;
+
+    // Get the actual DID (with SCID resolved) for subsequent documents
+    let scid = didwebvh.scid();
+    let did_id = did_template.replace("{SCID}", &scid);
+
+    println!(
+        "\t{}{}",
+        style("DID created: ").color256(34),
+        style(&did_id).color256(69),
+    );
+
+    // === Generate updates until we exceed target size ===
+    let mut previous_keys = next_keys;
+    let mut entry_count: u32 = 1;
+    let mut current_size: u64 = estimate_current_size(&didwebvh);
+
+    while current_size < target_bytes {
+        entry_count += 1;
+        let version_time = base_time + ChronoDuration::seconds(entry_count as i64);
+
+        let (new_next_keys, _) =
+            create_update_entry(
+                &mut didwebvh,
+                &mut secrets,
+                &previous_keys,
+                &did_id,
+                args.services,
+                entry_count,
+                version_time,
+            )
+            .await?;
+
+        previous_keys = new_next_keys;
+        current_size = estimate_current_size(&didwebvh);
+
+        if entry_count % 100 == 0 {
+            let size = Byte::from_u64(current_size).get_appropriate_unit(UnitType::Decimal);
+            println!(
+                "\t{}{}{}{:#.2}",
+                style("  entries: ").color256(34),
+                style(entry_count).color256(69),
+                style("  size: ").color256(34),
+                style(size).color256(199),
+            );
+        }
+    }
+
+    let gen_end = SystemTime::now();
+    let gen_duration_ms = gen_end.duration_since(gen_start).unwrap().as_millis();
+
+    // === Write to disk ===
+    let write_start = SystemTime::now();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open("did.jsonl")?;
+
+    let mut byte_count: u64 = 0;
+    for entry in didwebvh.log_entries().iter() {
+        let json_entry = serde_json::to_string(&entry.log_entry)?;
+        file.write_all(json_entry.as_bytes())?;
+        file.write_all(b"\n")?;
+        byte_count += json_entry.len() as u64 + 1;
+    }
+    let write_end = SystemTime::now();
+    let write_duration_ms = write_end.duration_since(write_start).unwrap().as_millis();
+
+    let file_size = Byte::from_u64(byte_count).get_appropriate_unit(UnitType::Decimal);
+
+    println!();
+    println!("{}", style("=== Generation Results ===").color256(214));
+    println!(
+        "\t{}{} {}{}",
+        style("LogEntries: ").color256(34),
+        style(entry_count).color256(69),
+        style("File size: ").color256(34),
+        style(format!("{file_size:#.2}")).color256(199),
+    );
+    println!(
+        "\t{}{}{}{} {}{}",
+        style("Generation: ").color256(34),
+        style(format!("{gen_duration_ms}ms")).color256(141),
+        style("  Write to disk: ").color256(34),
+        style(format!("{write_duration_ms}ms")).color256(141),
+        style("Total: ").color256(34),
+        style(format!("{}ms", gen_duration_ms + write_duration_ms)).color256(141),
+    );
+
+    let throughput = if gen_duration_ms + write_duration_ms > 0 {
+        (1000.0 / (gen_duration_ms + write_duration_ms) as f64) * entry_count as f64
+    } else {
+        0.0
+    };
+    println!(
+        "\t{}{}",
+        style("Throughput: ").color256(34),
+        style(format!("{throughput:.0} entries/sec")).color256(69),
+    );
+
+    // === Verify by loading and validating ===
+    println!();
+    println!(
+        "{}",
+        style("=== Verification ===").color256(214),
+    );
+
+    let mut verify_state = DIDWebVHState::default();
+
+    let load_start = SystemTime::now();
+    verify_state.load_log_entries_from_file("did.jsonl")?;
+    let load_end = SystemTime::now();
+    let load_ms = load_end.duration_since(load_start).unwrap().as_millis();
+    println!(
+        "\t{}{}",
+        style("Load from file: ").color256(34),
+        style(format!("{load_ms}ms")).color256(141),
+    );
+
+    let validate_start = SystemTime::now();
+    verify_state.validate()?;
+    let validate_end = SystemTime::now();
+    let validate_ms = validate_end.duration_since(validate_start).unwrap().as_millis();
+    println!(
+        "\t{}{}",
+        style("Validation: ").color256(34),
+        style(format!("{validate_ms}ms")).color256(141),
+    );
+
+    let total_verify_ms = load_ms + validate_ms;
+    let verify_throughput = if total_verify_ms > 0 {
+        (1000.0 / total_verify_ms as f64) * verify_state.log_entries().len() as f64
+    } else {
+        0.0
+    };
+    println!(
+        "\t{}{} {}{}",
+        style("Total verify: ").color256(34),
+        style(format!("{total_verify_ms}ms")).color256(141),
+        style("@ ").color256(34),
+        style(format!("{verify_throughput:.0} entries/sec")).color256(69),
+    );
+
+    println!();
+    println!(
+        "{}",
+        style("All log entries verified successfully!").color256(34),
+    );
+
+    Ok(())
+}
+
+/// Generate a signing key and two next-rotation keys
+async fn generate_keys(
+    secrets: &mut SimpleSecretsResolver,
+) -> Result<(Secret, Vec<Secret>)> {
+    let signing_key = DID::generate_did_key(KeyType::Ed25519)?.1;
+    secrets.insert(signing_key.clone()).await;
+
+    let next_key1 = DID::generate_did_key(KeyType::Ed25519)?.1;
+    secrets.insert(next_key1.clone()).await;
+    let next_key2 = DID::generate_did_key(KeyType::Ed25519)?.1;
+    secrets.insert(next_key2.clone()).await;
+
+    Ok((signing_key, vec![next_key1, next_key2]))
+}
+
+/// Build a DID document with multiple service endpoints to increase size
+fn build_did_document(
+    did_template: &str,
+    signing_key: &Secret,
+    num_services: usize,
+) -> Result<serde_json::Value> {
+    let pk = signing_key.get_public_keymultibase()?;
+
+    let services: Vec<serde_json::Value> = (0..num_services)
+        .map(|i| {
+            json!({
+                "id": format!("{did_template}#service-{i}"),
+                "type": "LinkedDomains",
+                "serviceEndpoint": format!("https://service-{i}.example.com/api/v1/endpoint")
+            })
+        })
+        .collect();
+
+    Ok(json!({
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1"
+        ],
+        "id": did_template,
+        "verificationMethod": [{
+            "id": format!("{did_template}#key-0"),
+            "type": "Multikey",
+            "publicKeyMultibase": pk,
+            "controller": did_template
+        }],
+        "authentication": [format!("{did_template}#key-0")],
+        "assertionMethod": [format!("{did_template}#key-0")],
+        "service": services
+    }))
+}
+
+/// Create an update log entry with key rotation
+async fn create_update_entry(
+    didwebvh: &mut DIDWebVHState,
+    secrets: &mut SimpleSecretsResolver,
+    previous_keys: &[Secret],
+    did_id: &str,
+    num_services: usize,
+    count: u32,
+    version_time: chrono::DateTime<FixedOffset>,
+) -> Result<(Vec<Secret>, ())> {
+    let old_entry = didwebvh
+        .log_entries()
+        .last()
+        .ok_or_else(|| anyhow!("No previous log entry found"))?;
+
+    let mut new_params = old_entry.validated_parameters.clone();
+
+    // Generate new next keys for pre-rotation
+    let next_key1 = DID::generate_did_key(KeyType::Ed25519)?.1;
+    secrets.insert(next_key1.clone()).await;
+    let next_key2 = DID::generate_did_key(KeyType::Ed25519)?.1;
+    secrets.insert(next_key2.clone()).await;
+
+    new_params.next_key_hashes = Some(Arc::new(vec![
+        Multibase::new(next_key1.get_public_keymultibase_hash()?),
+        Multibase::new(next_key2.get_public_keymultibase_hash()?),
+    ]));
+
+    // Rotate update keys to previous next keys
+    let update_keys = previous_keys
+        .iter()
+        .map(|s| Multibase::new(s.get_public_keymultibase().unwrap()))
+        .collect();
+    new_params.update_keys = Some(Arc::new(update_keys));
+
+    // Build an updated document with varied services to add bulk
+    let signing_key = previous_keys
+        .first()
+        .ok_or_else(|| anyhow!("No signing key available"))?;
+    let pk = signing_key.get_public_keymultibase()?;
+
+    let services: Vec<serde_json::Value> = (0..num_services)
+        .map(|i| {
+            json!({
+                "id": format!("{did_id}#service-{i}"),
+                "type": "LinkedDomains",
+                "serviceEndpoint": format!("https://service-{i}.example.com/api/v{count}/endpoint")
+            })
+        })
+        .collect();
+
+    let new_state = json!({
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1"
+        ],
+        "id": did_id,
+        "verificationMethod": [{
+            "id": format!("{did_id}#key-0"),
+            "type": "Multikey",
+            "publicKeyMultibase": pk,
+            "controller": did_id
+        }],
+        "authentication": [format!("{did_id}#key-0")],
+        "assertionMethod": [format!("{did_id}#key-0")],
+        "service": services
+    });
+
+    didwebvh
+        .create_log_entry(Some(version_time), &new_state, &new_params, signing_key)
+        .await?;
+
+    Ok((vec![next_key1, next_key2], ()))
+}
+
+/// Estimate the current serialized size of all log entries
+fn estimate_current_size(didwebvh: &DIDWebVHState) -> u64 {
+    didwebvh
+        .log_entries()
+        .iter()
+        .map(|e| serde_json::to_string(&e.log_entry).unwrap().len() as u64 + 1)
+        .sum()
+}

--- a/examples/generate_large_did.rs
+++ b/examples/generate_large_did.rs
@@ -18,12 +18,7 @@ use clap::Parser;
 use console::style;
 use didwebvh_rs::{DIDWebVHState, Multibase, parameters::Parameters, url::WebVHURL};
 use serde_json::json;
-use std::{
-    fs::OpenOptions,
-    io::Write,
-    sync::Arc,
-    time::SystemTime,
-};
+use std::{fs::OpenOptions, io::Write, sync::Arc, time::SystemTime};
 use tracing_subscriber::filter;
 
 #[derive(Parser, Debug)]
@@ -54,8 +49,8 @@ pub async fn main() -> Result<()> {
     let target_bytes = args.target_kb * 1024;
 
     // Parse the URL into a WebVHURL to properly derive the DID template
-    let parsed_url = url::Url::parse(&args.url)
-        .map_err(|e| anyhow!("Invalid URL '{}': {e}", args.url))?;
+    let parsed_url =
+        url::Url::parse(&args.url).map_err(|e| anyhow!("Invalid URL '{}': {e}", args.url))?;
     let webvh_url = WebVHURL::parse_url(&parsed_url)
         .map_err(|e| anyhow!("Cannot convert URL to WebVH DID: {e}"))?;
     // to_did_base() produces "did:webvh:{SCID}:domain%3Aport:path" with proper encoding
@@ -125,17 +120,16 @@ pub async fn main() -> Result<()> {
         entry_count += 1;
         let version_time = base_time + ChronoDuration::seconds(entry_count as i64);
 
-        let (new_next_keys, _) =
-            create_update_entry(
-                &mut didwebvh,
-                &mut secrets,
-                &previous_keys,
-                &did_id,
-                args.services,
-                entry_count,
-                version_time,
-            )
-            .await?;
+        let (new_next_keys, _) = create_update_entry(
+            &mut didwebvh,
+            &mut secrets,
+            &previous_keys,
+            &did_id,
+            args.services,
+            entry_count,
+            version_time,
+        )
+        .await?;
 
         previous_keys = new_next_keys;
         current_size = estimate_current_size(&didwebvh);
@@ -207,10 +201,7 @@ pub async fn main() -> Result<()> {
 
     // === Verify by loading and validating ===
     println!();
-    println!(
-        "{}",
-        style("=== Verification ===").color256(214),
-    );
+    println!("{}", style("=== Verification ===").color256(214),);
 
     let mut verify_state = DIDWebVHState::default();
 
@@ -227,7 +218,10 @@ pub async fn main() -> Result<()> {
     let validate_start = SystemTime::now();
     verify_state.validate()?;
     let validate_end = SystemTime::now();
-    let validate_ms = validate_end.duration_since(validate_start).unwrap().as_millis();
+    let validate_ms = validate_end
+        .duration_since(validate_start)
+        .unwrap()
+        .as_millis();
     println!(
         "\t{}{}",
         style("Validation: ").color256(34),
@@ -258,9 +252,7 @@ pub async fn main() -> Result<()> {
 }
 
 /// Generate a signing key and two next-rotation keys
-async fn generate_keys(
-    secrets: &mut SimpleSecretsResolver,
-) -> Result<(Secret, Vec<Secret>)> {
+async fn generate_keys(secrets: &mut SimpleSecretsResolver) -> Result<(Secret, Vec<Secret>)> {
     let signing_key = DID::generate_did_key(KeyType::Ed25519)?.1;
     secrets.insert(signing_key.clone()).await;
 

--- a/examples/resolve.rs
+++ b/examples/resolve.rs
@@ -1,18 +1,39 @@
 use chrono::{TimeDelta, Utc};
+use clap::Parser;
 use console::style;
 use didwebvh_rs::prelude::*;
-use std::env;
+use didwebvh_rs::resolve::{DEFAULT_MAX_RESPONSE_BYTES, ResolveOptions};
 use tracing_subscriber::filter;
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about = "Resolve a did:webvh DID",
+    long_about = "Resolve a did:webvh DID by fetching and verifying its log entries over HTTP(S).\n\n\
+        The resolver downloads the DID's did.jsonl (and optionally did-witness.json),\n\
+        validates all log entry signatures and parameter transitions, and displays\n\
+        the resolved DID Document along with WebVH metadata.\n\n\
+        Examples:\n  \
+          resolve did:webvh:<scid>:example.com\n  \
+          resolve did:webvh:<scid>:example.com%3A8080\n  \
+          resolve did:webvh:<scid>:example.com:custom:path\n  \
+          resolve did:webvh:<scid>:example.com --max-size-kb 500\n  \
+          resolve \"did:webvh:<scid>:example.com?versionId=2-Qm...\"",
+)]
+struct Args {
+    /// The DID to resolve (e.g. "did:webvh:<scid>:example.com")
+    did: String,
+
+    /// Maximum HTTP response size in KB. Responses larger than this limit are
+    /// rejected to prevent memory exhaustion. Applies independently to each
+    /// downloaded file (did.jsonl, did-witness.json).
+    #[arg(short = 'l', long, default_value_t = DEFAULT_MAX_RESPONSE_BYTES / 1024)]
+    max_size_kb: u64,
+}
 
 #[tokio::main]
 async fn main() {
-    let args: Vec<String> = env::args().collect();
-
-    // First argument is the command executed, second is the DID to parse
-    if args.len() != 2 {
-        eprintln!("Usage: {} <did:webvh>", args[0]);
-        std::process::exit(1);
-    }
+    let args = Args::parse();
 
     // construct a subscriber that prints formatted traces to stdout
     let subscriber = tracing_subscriber::fmt()
@@ -22,7 +43,12 @@ async fn main() {
     // use that subscriber to process traces emitted after this point
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
-    let elapsed = resolve(&args[1]).await;
+    let options = ResolveOptions {
+        max_response_bytes: args.max_size_kb * 1024,
+        ..ResolveOptions::default()
+    };
+
+    let elapsed = resolve(&args.did, options).await;
     println!();
     println!(
         "{}{}{}",
@@ -32,10 +58,17 @@ async fn main() {
     );
 }
 
-async fn resolve(did: &str) -> TimeDelta {
+async fn resolve(did: &str, options: ResolveOptions) -> TimeDelta {
+    let max_kb = options.max_response_bytes / 1024;
+    println!(
+        "{}{}",
+        style("Max response size: ").color256(69),
+        style(format!("{max_kb} KB")).color256(141),
+    );
+
     let mut webvh = DIDWebVHState::default();
     let start = Utc::now();
-    let (log_entry, meta) = match webvh.resolve(did, None, false).await {
+    let (log_entry, meta) = match webvh.resolve(did, options).await {
         Ok(res) => res,
         Err(e) => {
             panic!("Error: {e:?}");

--- a/examples/resolve.rs
+++ b/examples/resolve.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::filter;
           resolve did:webvh:<scid>:example.com%3A8080\n  \
           resolve did:webvh:<scid>:example.com:custom:path\n  \
           resolve did:webvh:<scid>:example.com --max-size-kb 500\n  \
-          resolve \"did:webvh:<scid>:example.com?versionId=2-Qm...\"",
+          resolve \"did:webvh:<scid>:example.com?versionId=2-Qm...\""
 )]
 struct Args {
     /// The DID to resolve (e.g. "did:webvh:<scid>:example.com")

--- a/examples/wizard/resolve.rs
+++ b/examples/wizard/resolve.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use console::style;
 use dialoguer::{Input, theme::ColorfulTheme};
-use didwebvh_rs::{DIDWebVHState, log_entry::LogEntryMethods};
+use didwebvh_rs::{DIDWebVHState, log_entry::LogEntryMethods, resolve::ResolveOptions};
 
 pub async fn resolve() {
     let did: String = Input::with_theme(&ColorfulTheme::default())
@@ -28,7 +28,7 @@ pub async fn resolve() {
     );
 
     let start = Utc::now();
-    match webvh.resolve(&did, None, false).await {
+    match webvh.resolve(&did, ResolveOptions::default()).await {
         Ok((log_entry, metadata)) => {
             let end = Utc::now();
             println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,6 @@ pub enum DIDWebVHError {
     /// from transport-level failures (where `status_code` is `None`).
     #[error("NetworkError: {message} (url: {url})")]
     NetworkError {
-
         /// The URL that was being fetched.
         url: String,
         /// HTTP status code, if the server responded.
@@ -142,7 +141,9 @@ pub enum DIDWebVHError {
     #[error("DID Query NotFound: {0}")]
     NotFound(String),
     /// The HTTP response body exceeds the maximum allowed size.
-    #[error("ResponseTooLarge: response from {url} exceeds maximum allowed size of {max_bytes} bytes")]
+    #[error(
+        "ResponseTooLarge: response from {url} exceeds maximum allowed size of {max_bytes} bytes"
+    )]
     ResponseTooLarge {
         /// The URL that was being fetched.
         url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ pub enum DIDWebVHError {
     /// from transport-level failures (where `status_code` is `None`).
     #[error("NetworkError: {message} (url: {url})")]
     NetworkError {
+
         /// The URL that was being fetched.
         url: String,
         /// HTTP status code, if the server responded.
@@ -140,6 +141,14 @@ pub enum DIDWebVHError {
     /// The requested DID or log entry version was not found.
     #[error("DID Query NotFound: {0}")]
     NotFound(String),
+    /// The HTTP response body exceeds the maximum allowed size.
+    #[error("ResponseTooLarge: response from {url} exceeds maximum allowed size of {max_bytes} bytes")]
+    ResponseTooLarge {
+        /// The URL that was being fetched.
+        url: String,
+        /// The maximum number of bytes allowed.
+        max_bytes: u64,
+    },
     /// The requested operation is not yet implemented.
     #[error("NotImplemented: {0}")]
     NotImplemented(String),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,7 @@ pub use crate::async_trait;
 pub use crate::create::{CreateDIDConfig, create_did};
 pub use crate::log_entry::LogEntryMethods;
 pub use crate::parameters::Parameters;
-pub use crate::witness::Witnesses;
-pub use crate::witness::proofs::WitnessProofCollection;
 #[cfg(feature = "network")]
 pub use crate::resolve::ResolveOptions;
+pub use crate::witness::Witnesses;
+pub use crate::witness::proofs::WitnessProofCollection;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,3 +15,5 @@ pub use crate::log_entry::LogEntryMethods;
 pub use crate::parameters::Parameters;
 pub use crate::witness::Witnesses;
 pub use crate::witness::proofs::WitnessProofCollection;
+#[cfg(feature = "network")]
+pub use crate::resolve::ResolveOptions;

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -38,16 +38,55 @@ pub mod ssi_resolve;
 
 pub mod implicit; // WebVH specification implies specific Services for a DID Document
 
+/// Default maximum HTTP response size: 200 KB.
+#[cfg(feature = "network")]
+pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 200 * 1024;
+
+/// Options for network-based DID resolution.
+#[cfg(feature = "network")]
+#[derive(Debug, Clone)]
+pub struct ResolveOptions {
+    /// Network timeout (default: 10 seconds).
+    pub timeout: Option<Duration>,
+    /// Download witnesses concurrently with log entries (default: false).
+    pub eager_witness_download: bool,
+    /// Maximum allowed HTTP response body size in bytes (default: 200 KB).
+    /// Applies independently to each downloaded file (did.jsonl, did-witness.json).
+    pub max_response_bytes: u64,
+}
+
+#[cfg(feature = "network")]
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            timeout: None,
+            eager_witness_download: false,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        }
+    }
+}
+
 /// HTTP client helpers for fetching DID log entries and witness proofs.
 #[cfg(feature = "network")]
 pub struct DIDWebVH;
 
 #[cfg(feature = "network")]
 impl DIDWebVH {
-    // Handles the fetching of the file from a given URL
-    async fn download_file(client: Client, url: Url) -> Result<String, DIDWebVHError> {
+    /// Fetches a file from the given URL, enforcing a maximum response body size.
+    ///
+    /// The size limit is checked in two ways:
+    /// 1. If the server provides a `Content-Length` header, the response is rejected
+    ///    immediately when the advertised size exceeds `max_bytes`.
+    /// 2. The body is read in chunks, and the cumulative size is checked against
+    ///    `max_bytes` as data arrives. This catches cases where `Content-Length` is
+    ///    absent or inaccurate (e.g. chunked transfer encoding).
+    async fn download_file(
+        client: Client,
+        url: Url,
+        max_bytes: u64,
+    ) -> Result<String, DIDWebVHError> {
         let url_str = url.to_string();
-        let response =
+        let mut response =
             client
                 .get(url.clone())
                 .send()
@@ -58,28 +97,59 @@ impl DIDWebVH {
                     message: format!("Request failed: {e}"),
                 })?;
 
-        if response.status() == StatusCode::OK {
-            response
-                .text()
-                .await
-                .map_err(|e| DIDWebVHError::NetworkError {
-                    url: url_str,
-                    status_code: Some(200),
-                    message: format!("Failed to read response body: {e}"),
-                })
-        } else {
+        if response.status() != StatusCode::OK {
             let status = response.status().as_u16();
             warn!("url ({url_str}): HTTP Status code = {status}");
-            Err(DIDWebVHError::NetworkError {
+            return Err(DIDWebVHError::NetworkError {
                 url: url_str,
                 status_code: Some(status),
                 message: format!("HTTP {status}"),
-            })
+            });
         }
+
+        // Early rejection based on Content-Length header
+        if let Some(content_length) = response.content_length()
+            && content_length > max_bytes
+        {
+            return Err(DIDWebVHError::ResponseTooLarge {
+                url: url_str,
+                max_bytes,
+            });
+        }
+
+        // Read body in chunks, enforcing the size limit as data arrives
+        let mut body = Vec::new();
+        let mut total_bytes: u64 = 0;
+        while let Some(chunk) = response.chunk().await.map_err(|e| {
+            DIDWebVHError::NetworkError {
+                url: url_str.clone(),
+                status_code: Some(200),
+                message: format!("Failed to read response body: {e}"),
+            }
+        })? {
+            total_bytes += chunk.len() as u64;
+            if total_bytes > max_bytes {
+                return Err(DIDWebVHError::ResponseTooLarge {
+                    url: url_str,
+                    max_bytes,
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        String::from_utf8(body).map_err(|e| DIDWebVHError::NetworkError {
+            url: url_str,
+            status_code: Some(200),
+            message: format!("Response body is not valid UTF-8: {e}"),
+        })
     }
 
     /// Handles all processing and fetching for LogEntry file
-    async fn get_log_entries(url: WebVHURL, client: Client) -> Result<String, DIDWebVHError> {
+    async fn get_log_entries(
+        url: WebVHURL,
+        client: Client,
+        max_bytes: u64,
+    ) -> Result<String, DIDWebVHError> {
         let log_entries_url = match url.get_http_url(Some("did.jsonl")) {
             Ok(url) => url,
             Err(e) => {
@@ -90,11 +160,15 @@ impl DIDWebVH {
             }
         };
 
-        Self::download_file(client, log_entries_url).await
+        Self::download_file(client, log_entries_url, max_bytes).await
     }
 
     /// Handles all processing and fetching for witness proofs
-    async fn get_witness_proofs(url: WebVHURL, client: Client) -> Result<String, DIDWebVHError> {
+    async fn get_witness_proofs(
+        url: WebVHURL,
+        client: Client,
+        max_bytes: u64,
+    ) -> Result<String, DIDWebVHError> {
         let witness_url = match url.get_http_url(Some("did-witness.json")) {
             Ok(url) => url,
             Err(e) => {
@@ -105,7 +179,7 @@ impl DIDWebVH {
             }
         };
 
-        Self::download_file(client, witness_url).await
+        Self::download_file(client, witness_url, max_bytes).await
     }
 }
 
@@ -313,16 +387,12 @@ impl DIDWebVHState {
     ///
     /// # Arguments
     /// * `did` — The DID to resolve (may include query parameters like `?versionId=...`).
-    /// * `timeout` — Network timeout (default: 10 seconds).
-    /// * `eager_witness_download` — If `true`, download `did.jsonl` and `did-witness.json`
-    ///   concurrently (faster when witnesses are expected). If `false` (recommended default),
-    ///   download `did.jsonl` first, then only fetch `did-witness.json` when the log entries
-    ///   actually configure witnesses.
+    /// * `options` — Network options (timeout, eager witness download, max response size).
+    ///   Use [`ResolveOptions::default()`] for sensible defaults (10 s timeout, 200 KB limit).
     pub async fn resolve(
         &mut self,
         did: &str,
-        timeout: Option<Duration>,
-        eager_witness_download: bool,
+        options: ResolveOptions,
     ) -> Result<(&LogEntry, MetaData), DIDWebVHError> {
         let _span = span!(Level::DEBUG, "resolve", DID = did);
         async move {
@@ -335,22 +405,24 @@ impl DIDWebVHState {
             }
 
             if !self.validated || self.expires < Utc::now() {
+                let max_bytes = options.max_response_bytes;
+
                 // If building for WASM then don't use tokio::spawn
                 // This means sequential retrieval of files
                 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                 let (log_entries, witness_proofs) = {
-                    trace!("timeout is not available in WASM builds! {timeout:#?}");
+                    trace!("timeout is not available in WASM builds! {:#?}", options.timeout);
                     let client = reqwest::Client::new();
 
                     let raw_entries =
-                        DIDWebVH::get_log_entries(parsed_did_url.clone(), client.clone()).await?;
+                        DIDWebVH::get_log_entries(parsed_did_url.clone(), client.clone(), max_bytes).await?;
                     let log_entries = Self::parse_log_entries(&raw_entries)?;
                     Self::validate_log_entries(&log_entries, did)?;
 
                     let needs_witnesses = Self::needs_witness_proofs(&log_entries);
-                    let witness_proofs = if eager_witness_download || needs_witnesses {
+                    let witness_proofs = if options.eager_witness_download || needs_witnesses {
                         let raw_result =
-                            DIDWebVH::get_witness_proofs(parsed_did_url.clone(), client.clone())
+                            DIDWebVH::get_witness_proofs(parsed_did_url.clone(), client.clone(), max_bytes)
                                 .await;
                         Self::resolve_witness_proofs(raw_result, needs_witnesses)?
                     } else {
@@ -364,7 +436,7 @@ impl DIDWebVHState {
                 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                 let (log_entries, witness_proofs) = {
                     // Set network timeout values. Will default to 10 seconds for any reasons
-                    let network_timeout = timeout.unwrap_or(Duration::from_secs(10));
+                    let network_timeout = options.timeout.unwrap_or(Duration::from_secs(10));
 
                     let client = reqwest::ClientBuilder::new()
                         .timeout(network_timeout)
@@ -375,15 +447,17 @@ impl DIDWebVHState {
                             message: format!("Failed to build HTTP client: {e}"),
                         })?;
 
-                    if eager_witness_download {
+                    if options.eager_witness_download {
                         // Eager path: download both files concurrently
                         let r1 = tokio::spawn(DIDWebVH::get_log_entries(
                             parsed_did_url.clone(),
                             client.clone(),
+                            max_bytes,
                         ));
                         let r2 = tokio::spawn(DIDWebVH::get_witness_proofs(
                             parsed_did_url.clone(),
                             client.clone(),
+                            max_bytes,
                         ));
 
                         let raw_entries = r1.await.map_err(|e| {
@@ -411,6 +485,7 @@ impl DIDWebVHState {
                         let raw_entries = tokio::spawn(DIDWebVH::get_log_entries(
                             parsed_did_url.clone(),
                             client.clone(),
+                            max_bytes,
                         ))
                         .await
                         .map_err(|e| DIDWebVHError::NetworkError {
@@ -426,6 +501,7 @@ impl DIDWebVHState {
                             let raw_result = DIDWebVH::get_witness_proofs(
                                 parsed_did_url.clone(),
                                 client.clone(),
+                                max_bytes,
                             )
                             .await;
                             Self::resolve_witness_proofs(raw_result, true)?
@@ -455,10 +531,9 @@ impl DIDWebVHState {
     pub async fn resolve_owned(
         &mut self,
         did: &str,
-        timeout: Option<Duration>,
-        eager_witness_download: bool,
+        options: ResolveOptions,
     ) -> Result<(LogEntry, MetaData), DIDWebVHError> {
-        let (entry, metadata) = self.resolve(did, timeout, eager_witness_download).await?;
+        let (entry, metadata) = self.resolve(did, options).await?;
         Ok((entry.clone(), metadata))
     }
 }
@@ -532,6 +607,7 @@ impl DIDWebVHState {
 
 #[cfg(all(test, feature = "network"))]
 mod tests {
+    use super::ResolveOptions;
     use crate::{DIDWebVHError, DIDWebVHState};
 
     // ===== Mock-based resolve tests =====
@@ -581,7 +657,7 @@ mod tests {
         let (_server, did) = setup_mock_resolve().await;
 
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
         assert!(result.is_ok(), "resolve failed: {result:?}");
     }
 
@@ -597,7 +673,7 @@ mod tests {
             .await;
 
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, true).await;
+        let result = webvh.resolve(&did, ResolveOptions { eager_witness_download: true, ..ResolveOptions::default() }).await;
         assert!(result.is_ok(), "eager resolve failed: {result:?}");
     }
 
@@ -610,13 +686,13 @@ mod tests {
 
         // First resolve to get the versionId
         let mut webvh = DIDWebVHState::default();
-        let (entry, _) = webvh.resolve(&did, None, false).await.unwrap();
+        let (entry, _) = webvh.resolve(&did, ResolveOptions::default()).await.unwrap();
         let version_id = entry.get_version_id().to_string();
 
         // Resolve again with ?versionId=...
         let mut webvh2 = DIDWebVHState::default();
         let did_with_version = format!("{did}?versionId={version_id}");
-        let result = webvh2.resolve(&did_with_version, None, false).await;
+        let result = webvh2.resolve(&did_with_version, ResolveOptions::default()).await;
         assert!(result.is_ok(), "versionId resolve failed: {result:?}");
     }
 
@@ -629,13 +705,13 @@ mod tests {
 
         // Resolve to get a valid versionTime
         let mut webvh = DIDWebVHState::default();
-        let (entry, _) = webvh.resolve(&did, None, false).await.unwrap();
+        let (entry, _) = webvh.resolve(&did, ResolveOptions::default()).await.unwrap();
         let version_time = entry.get_version_time_string();
 
         // Resolve again with ?versionTime=...
         let mut webvh2 = DIDWebVHState::default();
         let did_with_time = format!("{did}?versionTime={version_time}");
-        let result = webvh2.resolve(&did_with_time, None, false).await;
+        let result = webvh2.resolve(&did_with_time, ResolveOptions::default()).await;
         assert!(result.is_ok(), "versionTime resolve failed: {result:?}");
     }
 
@@ -663,7 +739,7 @@ mod tests {
 
         let did = mock_did(&server, "testscid404");
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
 
         match result {
             Err(DIDWebVHError::NetworkError {
@@ -686,7 +762,7 @@ mod tests {
 
         let did = mock_did(&server, "testscid500");
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
 
         match result {
             Err(DIDWebVHError::NetworkError {
@@ -709,7 +785,7 @@ mod tests {
 
         let did = mock_did(&server, "testscidbad");
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
 
         match result {
             Err(DIDWebVHError::LogEntryError(_)) => {} // expected: invalid JSON
@@ -729,7 +805,7 @@ mod tests {
 
         let did = mock_did(&server, "testscidempty");
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
 
         match result {
             Err(DIDWebVHError::NotFound(msg)) => {
@@ -756,7 +832,13 @@ mod tests {
         let did = mock_did(&server, "testscidtimeout");
         let mut webvh = DIDWebVHState::default();
         let result = webvh
-            .resolve(&did, Some(Duration::from_secs(1)), false)
+            .resolve(
+                &did,
+                ResolveOptions {
+                    timeout: Some(Duration::from_secs(1)),
+                    ..ResolveOptions::default()
+                },
+            )
             .await;
 
         match result {
@@ -775,7 +857,13 @@ mod tests {
         let did = "did:webvh:testscidrefused:localhost%3A1";
         let mut webvh = DIDWebVHState::default();
         let result = webvh
-            .resolve(did, Some(std::time::Duration::from_secs(2)), false)
+            .resolve(
+                did,
+                ResolveOptions {
+                    timeout: Some(std::time::Duration::from_secs(2)),
+                    ..ResolveOptions::default()
+                },
+            )
             .await;
 
         match result {
@@ -800,7 +888,7 @@ mod tests {
 
         let did = mock_did(&server, "testscidfields");
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, None, false).await;
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
 
         match result {
             Err(DIDWebVHError::NetworkError {
@@ -874,7 +962,7 @@ mod tests {
 
         // Resolve via network
         let mut webvh_net = DIDWebVHState::default();
-        let (net_entry, _) = webvh_net.resolve(&did, None, false).await.unwrap();
+        let (net_entry, _) = webvh_net.resolve(&did, ResolveOptions::default()).await.unwrap();
         let net_doc = net_entry.get_did_document().unwrap();
 
         // Get the raw log from the network-resolved state
@@ -953,6 +1041,69 @@ mod tests {
         assert!(
             result.is_err(),
             "resolve_log should fail with tampered data"
+        );
+    }
+
+    // ===== Response size limit tests =====
+
+    /// Tests that a response with a body exceeding the limit is rejected.
+    #[tokio::test]
+    async fn resolve_rejects_large_response_body() {
+        let server = MockServer::start().await;
+        // Create a body larger than DEFAULT_MAX_RESPONSE_BYTES (200 KB)
+        let large_body = "x".repeat(210 * 1024);
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(200).set_body_string(&large_body))
+            .mount(&server)
+            .await;
+
+        let did = mock_did(&server, "testscidlarge");
+        let mut webvh = DIDWebVHState::default();
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
+
+        match result {
+            Err(DIDWebVHError::ResponseTooLarge { max_bytes, .. }) => {
+                assert_eq!(max_bytes, super::DEFAULT_MAX_RESPONSE_BYTES);
+            }
+            other => panic!("Expected ResponseTooLarge, got: {other:?}"),
+        }
+    }
+
+    /// Tests that a custom max_response_bytes limit is enforced.
+    #[tokio::test]
+    async fn resolve_custom_size_limit() {
+        let (_server, did) = setup_mock_resolve().await;
+
+        // Use an extremely small limit that the valid response will exceed
+        let mut webvh = DIDWebVHState::default();
+        let result = webvh
+            .resolve(
+                &did,
+                ResolveOptions {
+                    max_response_bytes: 10, // 10 bytes — too small for any DID log
+                    ..ResolveOptions::default()
+                },
+            )
+            .await;
+
+        match result {
+            Err(DIDWebVHError::ResponseTooLarge { max_bytes, .. }) => {
+                assert_eq!(max_bytes, 10);
+            }
+            other => panic!("Expected ResponseTooLarge, got: {other:?}"),
+        }
+    }
+
+    /// Tests that normal-sized responses pass the default size limit.
+    #[tokio::test]
+    async fn resolve_normal_response_passes_size_check() {
+        let (_server, did) = setup_mock_resolve().await;
+
+        let mut webvh = DIDWebVHState::default();
+        let result = webvh.resolve(&did, ResolveOptions::default()).await;
+        assert!(
+            result.is_ok(),
+            "Normal response should pass size check: {result:?}"
         );
     }
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -120,13 +120,15 @@ impl DIDWebVH {
         // Read body in chunks, enforcing the size limit as data arrives
         let mut body = Vec::new();
         let mut total_bytes: u64 = 0;
-        while let Some(chunk) = response.chunk().await.map_err(|e| {
-            DIDWebVHError::NetworkError {
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| DIDWebVHError::NetworkError {
                 url: url_str.clone(),
                 status_code: Some(200),
                 message: format!("Failed to read response body: {e}"),
-            }
-        })? {
+            })?
+        {
             total_bytes += chunk.len() as u64;
             if total_bytes > max_bytes {
                 return Err(DIDWebVHError::ResponseTooLarge {
@@ -673,7 +675,15 @@ mod tests {
             .await;
 
         let mut webvh = DIDWebVHState::default();
-        let result = webvh.resolve(&did, ResolveOptions { eager_witness_download: true, ..ResolveOptions::default() }).await;
+        let result = webvh
+            .resolve(
+                &did,
+                ResolveOptions {
+                    eager_witness_download: true,
+                    ..ResolveOptions::default()
+                },
+            )
+            .await;
         assert!(result.is_ok(), "eager resolve failed: {result:?}");
     }
 
@@ -686,13 +696,18 @@ mod tests {
 
         // First resolve to get the versionId
         let mut webvh = DIDWebVHState::default();
-        let (entry, _) = webvh.resolve(&did, ResolveOptions::default()).await.unwrap();
+        let (entry, _) = webvh
+            .resolve(&did, ResolveOptions::default())
+            .await
+            .unwrap();
         let version_id = entry.get_version_id().to_string();
 
         // Resolve again with ?versionId=...
         let mut webvh2 = DIDWebVHState::default();
         let did_with_version = format!("{did}?versionId={version_id}");
-        let result = webvh2.resolve(&did_with_version, ResolveOptions::default()).await;
+        let result = webvh2
+            .resolve(&did_with_version, ResolveOptions::default())
+            .await;
         assert!(result.is_ok(), "versionId resolve failed: {result:?}");
     }
 
@@ -705,13 +720,18 @@ mod tests {
 
         // Resolve to get a valid versionTime
         let mut webvh = DIDWebVHState::default();
-        let (entry, _) = webvh.resolve(&did, ResolveOptions::default()).await.unwrap();
+        let (entry, _) = webvh
+            .resolve(&did, ResolveOptions::default())
+            .await
+            .unwrap();
         let version_time = entry.get_version_time_string();
 
         // Resolve again with ?versionTime=...
         let mut webvh2 = DIDWebVHState::default();
         let did_with_time = format!("{did}?versionTime={version_time}");
-        let result = webvh2.resolve(&did_with_time, ResolveOptions::default()).await;
+        let result = webvh2
+            .resolve(&did_with_time, ResolveOptions::default())
+            .await;
         assert!(result.is_ok(), "versionTime resolve failed: {result:?}");
     }
 
@@ -962,7 +982,10 @@ mod tests {
 
         // Resolve via network
         let mut webvh_net = DIDWebVHState::default();
-        let (net_entry, _) = webvh_net.resolve(&did, ResolveOptions::default()).await.unwrap();
+        let (net_entry, _) = webvh_net
+            .resolve(&did, ResolveOptions::default())
+            .await
+            .unwrap();
         let net_doc = net_entry.get_did_document().unwrap();
 
         // Get the raw log from the network-resolved state

--- a/src/resolve/ssi_resolve.rs
+++ b/src/resolve/ssi_resolve.rs
@@ -6,7 +6,11 @@
 *   If you want greater control and caching then please use the DIDWebVHState.resolve() method directly
 */
 
-use crate::{DIDWebVHError, DIDWebVHState, log_entry::LogEntryMethods, resolve::DIDWebVH};
+use crate::{
+    DIDWebVHError, DIDWebVHState,
+    log_entry::LogEntryMethods,
+    resolve::{DIDWebVH, ResolveOptions},
+};
 use ssi::dids::{
     DIDMethod, DIDMethodResolver, Document,
     document::{
@@ -35,7 +39,7 @@ impl DIDMethodResolver for DIDWebVH {
         );
         async move {
             let mut state = DIDWebVHState::default();
-            match state.resolve(method_specific_id, None, false).await {
+            match state.resolve(method_specific_id, ResolveOptions::default()).await {
                 Ok((log_entry, _)) => {
                     let document: Document = serde_json::from_value(log_entry.get_state().clone())
                         .map_err(|e| {

--- a/src/resolve/ssi_resolve.rs
+++ b/src/resolve/ssi_resolve.rs
@@ -39,7 +39,10 @@ impl DIDMethodResolver for DIDWebVH {
         );
         async move {
             let mut state = DIDWebVHState::default();
-            match state.resolve(method_specific_id, ResolveOptions::default()).await {
+            match state
+                .resolve(method_specific_id, ResolveOptions::default())
+                .await
+            {
                 Ok((log_entry, _)) => {
                     let document: Document = serde_json::from_value(log_entry.get_state().clone())
                         .map_err(|e| {


### PR DESCRIPTION
## Summary

- **HTTP response size limits** — `download_file()` now enforces a maximum response body size (default 200 KB) to prevent memory exhaustion from malicious or misconfigured servers. Checks `Content-Length` header for early rejection, then reads body in chunks with a running byte counter as fallback.
- **`ResolveOptions` struct** — Replaces the `timeout` + `eager_witness_download` parameters on `resolve()` / `resolve_owned()` with a single options struct that also carries `max_response_bytes`. This is a **breaking API change**.
- **`ResponseTooLarge` error variant** — New `DIDWebVHError::ResponseTooLarge { url, max_bytes }` for size-limit rejections.
- **`generate_large_did` example** — Generates a valid 1 MB+ `did.jsonl` with backdated timestamps for benchmarking. Accepts `--url` (properly parsed via `WebVHURL`), `--target-kb`, and `--services` flags with full timing output.
- **`resolve` example improvements** — Now uses `clap` with `--max-size-kb` (`-l`) flag and detailed `--help` output.
- **Version bump to 0.4.0** for the breaking `resolve()` signature change.

## Test plan

- [ ] `cargo test` — all 396 tests pass including 3 new size-limit tests
- [ ] `cargo clippy` — no warnings
- [ ] `cargo run --example generate_large_did -- --url https://example.com` — generates 1 MB+ valid did.jsonl
- [ ] `cargo run --example resolve -- --help` — shows detailed help with examples
- [ ] Verify `ResolveOptions::default()` preserves previous default behavior (10s timeout, no eager witness, 200 KB limit)