### PR TITLE
fix: implicit service ID spec compliance + PQC example improvements (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # didwebvh-rs Changelog history
 
+## 30th April 2026
+
+### Release 0.5.2 — DID Core service ID compliance
+
+Fixes a resolution-time interop break with typed DID-Document parsers
+(notably `affinidi-did-common::DIDDocument`, whose `service[].id` field
+is `url::Url`). Resolution now produces documents that satisfy DID Core
+1.0 §5.4.
+
+#### Fixed
+
+- **Implicit `#files` and `#whois` services now use absolute-URI IDs.**
+  Previously the resolver emitted relative-fragment IDs (`"#files"`,
+  `"#whois"`) to match the didwebvh-test-suite reference output and the
+  didwebvh-ts implementation. DID Core 1.0 §5.4 requires service `id`
+  to be a URI per RFC 3986 — which mandates a scheme — so a
+  fragment-only relative reference is a URI-reference, not a URI, and
+  is rejected by spec-compliant typed parsers with
+  `"relative URL without a base: '#files'"`. `get_did_document()` and
+  `to_web_did()` now emit `"<did>#files"` / `"<did>#whois"`. The
+  duplicate-detection logic still recognises both forms, so existing
+  user-supplied services keep working unchanged.
+
+#### Examples
+
+- **`generate_history` example.** Adds a "Run Summary" block reporting
+  total keys generated (split into update vs witness), witness/watcher
+  swap counts, witness proofs created, and witness proofs after
+  optimisation. Fixes a panic on `--witnesses 0` and a stale
+  `did-witness.json` load on the no-witness path. Wires up
+  `WitnessVerifyOptions::with_extra_allowed_suite` so
+  `--key-type ml-dsa-44` validates end-to-end without manual config.
+
 ## 22nd April 2026
 
 ### Release 0.5.1 — spec-compliance patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.1"
+version = "0.5.2"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"

--- a/examples/generate_history.rs
+++ b/examples/generate_history.rs
@@ -25,7 +25,7 @@
 #[path = "common/suite.rs"]
 mod suite;
 
-use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
 use affinidi_secrets_resolver::{SecretsResolver, SimpleSecretsResolver, secrets::Secret};
 use anyhow::{Result, anyhow, bail};
 use byte_unit::{Byte, UnitType};
@@ -36,7 +36,7 @@ use didwebvh_rs::{
     DIDWebVHState, Multibase,
     did_key::generate_did_key,
     parameters::Parameters,
-    witness::{Witness, Witnesses},
+    witness::{Witness, WitnessVerifyOptions, Witnesses},
 };
 use format_num::format_num;
 use rand::{RngExt, distr::Alphabetic};
@@ -311,8 +311,21 @@ pub async fn main() -> Result<()> {
         sleep(Duration::from_secs(3));
     }
 
+    // Witness proofs inherit their cryptosuite from the signer's key type.
+    // The didwebvh 1.0 spec mandates `eddsa-jcs-2022` for witnesses, so
+    // anything else (notably the PQC suites this example can opt into via
+    // `--key-type`) must be explicitly admitted at verify time.
+    let mut verify_options = WitnessVerifyOptions::new();
+    if let Some(suite) = CryptoSuite::default_for_key_type(args.key_type.key_type())
+        && suite != CryptoSuite::EddsaJcs2022
+    {
+        verify_options = verify_options.with_extra_allowed_suite(suite);
+    }
+
     let start3 = SystemTime::now();
-    verify_state.validate()?.assert_complete()?;
+    verify_state
+        .validate_with(&verify_options)?
+        .assert_complete()?;
     let end = SystemTime::now();
 
     println!();

--- a/examples/generate_history.rs
+++ b/examples/generate_history.rs
@@ -300,33 +300,38 @@ pub async fn main() -> Result<()> {
     );
     let mut total_validation = end.duration_since(start).unwrap().as_millis();
 
-    if !args.interactive {
-        println!("{}", style("Sleeping for 3 seconds...").color256(214));
-        sleep(Duration::from_secs(3));
+    // Only touch did-witness.json when this run actually wrote it. Loading
+    // unconditionally would otherwise pick up a stale file from a previous
+    // run with `--witnesses > 0` and report bogus proof counts.
+    if args.witnesses > 0 {
+        if !args.interactive {
+            println!("{}", style("Sleeping for 3 seconds...").color256(214));
+            sleep(Duration::from_secs(3));
+        }
+
+        let start2 = SystemTime::now();
+        verify_state.load_witness_proofs_from_file("did-witness.json");
+        let end = SystemTime::now();
+
+        let throughput = (1000.0 / end.duration_since(start2).unwrap().as_millis() as f64)
+            * verify_state.witness_proofs().get_total_count() as f64;
+        let throughput = format_num!(",.02", throughput);
+
+        println!(
+            "\t{}{} {} {}{}",
+            style("Reading Witness-Proofs from file Duration: ").color256(34),
+            style(format!(
+                "{}ms",
+                end.duration_since(start2).unwrap().as_millis()
+            ))
+            .color256(141),
+            style("@").color256(34),
+            style(throughput).color256(69),
+            style(" Witness-Proofs/Second throughput").color256(34),
+        );
+
+        total_validation += end.duration_since(start2).unwrap().as_millis();
     }
-
-    let start2 = SystemTime::now();
-    verify_state.load_witness_proofs_from_file("did-witness.json");
-    let end = SystemTime::now();
-
-    let throughput = (1000.0 / end.duration_since(start2).unwrap().as_millis() as f64)
-        * verify_state.witness_proofs().get_total_count() as f64;
-    let throughput = format_num!(",.02", throughput);
-
-    println!(
-        "\t{}{} {} {}{}",
-        style("Reading Witness-Proofs from file Duration: ").color256(34),
-        style(format!(
-            "{}ms",
-            end.duration_since(start2).unwrap().as_millis()
-        ))
-        .color256(141),
-        style("@").color256(34),
-        style(throughput).color256(69),
-        style(" Witness-Proofs/Second throughput").color256(34),
-    );
-
-    total_validation += end.duration_since(start2).unwrap().as_millis();
 
     if !args.interactive {
         println!("{}", style("Sleeping for 3 seconds...").color256(214));
@@ -554,21 +559,24 @@ async fn generate_did(
         None
     };
 
-    let params = Parameters::new()
+    let mut builder = Parameters::new();
+    builder
         .with_portable(true)
         .with_update_keys(vec![signing_did1_secret.get_public_keymultibase()?])
         .with_next_key_hashes(vec![
             next_key1.get_public_keymultibase_hash()?,
             next_key2.get_public_keymultibase_hash()?,
         ])
-        .with_witnesses(witness.unwrap())
         .with_watchers(vec![
             "https://watcher-1.affinidi.com/v1/webvh".to_string(),
             "https://watcher-2.affinidi.com/v1/webvh".to_string(),
             "https://watcher-3.affinidi.com/v1/webvh".to_string(),
         ])
-        .with_ttl(3600)
-        .build();
+        .with_ttl(3600);
+    if let Some(w) = witness {
+        builder.with_witnesses(w);
+    }
+    let params = builder.build();
 
     let _ = didwebvh
         .create_log_entry(

--- a/examples/generate_history.rs
+++ b/examples/generate_history.rs
@@ -51,6 +51,18 @@ use std::{
 use suite::Suite;
 use tracing_subscriber::filter;
 
+/// Counters tracked across a generate_history run so the summary at the
+/// end can report keys generated, proofs created, and rotation events
+/// without re-deriving them from the log.
+#[derive(Default)]
+struct Stats {
+    update_keys_generated: u64,
+    witness_keys_generated: u64,
+    witness_swaps: u32,
+    watcher_swaps: u32,
+    proofs_created: u64,
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -86,6 +98,7 @@ pub async fn main() -> Result<()> {
 
     let mut didwebvh = DIDWebVHState::default();
     let mut secrets = SimpleSecretsResolver::new(&[]).await;
+    let mut stats = Stats::default();
 
     println!(
         "{}{}{}{}{}",
@@ -125,12 +138,21 @@ pub async fn main() -> Result<()> {
         (Utc::now() - ChronoDuration::seconds(i64::from(args.count) + 10)).fixed_offset();
 
     // Generate initial DID
-    let mut next = generate_did(&mut didwebvh, &mut secrets, &args, base_time).await?;
+    let mut next = generate_did(&mut didwebvh, &mut secrets, &mut stats, &args, base_time).await?;
 
     // Loop for count months (first entry represents the first month)
     for i in 2..=args.count {
         let version_time = base_time + ChronoDuration::seconds(i64::from(i));
-        next = create_log_entry(&mut didwebvh, &mut secrets, &next, i, &args, version_time).await?;
+        next = create_log_entry(
+            &mut didwebvh,
+            &mut secrets,
+            &mut stats,
+            &next,
+            i,
+            &args,
+            version_time,
+        )
+        .await?;
     }
 
     let end = SystemTime::now();
@@ -353,12 +375,109 @@ pub async fn main() -> Result<()> {
         style(" Entries/Second throughput").color256(34),
     );
 
+    print_run_summary(&stats, &didwebvh, &verify_state, &args);
+
     Ok(())
+}
+
+fn print_run_summary(
+    stats: &Stats,
+    didwebvh: &DIDWebVHState,
+    verify_state: &DIDWebVHState,
+    args: &Args,
+) {
+    let total_keys = stats.update_keys_generated + stats.witness_keys_generated;
+    let proofs_after_optimise = didwebvh.witness_proofs().get_total_count();
+    let proofs_loaded = verify_state.witness_proofs().get_total_count();
+
+    println!();
+    println!("{}", style("=== Run Summary ===").color256(214));
+    println!(
+        "\t{}{}",
+        style("Cryptographic suite: ").color256(34),
+        style(format!("{:?}", args.key_type.key_type())).color256(69),
+    );
+    println!(
+        "\t{}{}",
+        style("Log entries created: ").color256(34),
+        style(format_num!(",.0", didwebvh.log_entries().len() as f64)).color256(69),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Update keys generated: ").color256(34),
+        style(format_num!(",.0", stats.update_keys_generated as f64)).color256(69),
+        style("(1 initial signing key + 2 next-key hashes per entry)").color256(245),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Witness keys generated: ").color256(34),
+        style(format_num!(",.0", stats.witness_keys_generated as f64)).color256(69),
+        style(format!(
+            "({} initial + {} swap{})",
+            args.witnesses,
+            stats.witness_swaps,
+            if stats.witness_swaps == 1 { "" } else { "s" },
+        ))
+        .color256(245),
+    );
+    println!(
+        "\t{}{}",
+        style("Total keys generated: ").color256(34),
+        style(format_num!(",.0", total_keys as f64)).color256(69),
+    );
+    println!(
+        "\t{}{}",
+        style("Witness swaps: ").color256(34),
+        style(stats.witness_swaps).color256(69),
+    );
+    println!(
+        "\t{}{}",
+        style("Watcher swaps: ").color256(34),
+        style(stats.watcher_swaps).color256(69),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Witness proofs created: ").color256(34),
+        style(format_num!(",.0", stats.proofs_created as f64)).color256(69),
+        style(format!(
+            "({} entries × {} witnesses)",
+            args.count, args.witnesses
+        ))
+        .color256(245),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Witness proofs after optimisation: ").color256(34),
+        style(format_num!(",.0", proofs_after_optimise as f64)).color256(69),
+        style(format!(
+            "(saved {})",
+            format_num!(
+                ",.0",
+                stats
+                    .proofs_created
+                    .saturating_sub(proofs_after_optimise as u64) as f64
+            )
+        ))
+        .color256(245),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Log entries verified: ").color256(34),
+        style(format_num!(",.0", verify_state.log_entries().len() as f64)).color256(69),
+        style("(reloaded from did.jsonl)").color256(245),
+    );
+    println!(
+        "\t{}{} {}",
+        style("Witness proofs loaded for verification: ").color256(34),
+        style(format_num!(",.0", proofs_loaded as f64)).color256(69),
+        style("(from did-witness.json)").color256(245),
+    );
 }
 
 async fn generate_did(
     didwebvh: &mut DIDWebVHState,
     secrets: &mut SimpleSecretsResolver,
+    stats: &mut Stats,
     args: &Args,
     version_time: DateTime<FixedOffset>,
 ) -> Result<Vec<Secret>> {
@@ -405,12 +524,14 @@ async fn generate_did(
     // Generate updateKey for first log entry
     let signing_did1_secret = generate_did_key(args.key_type.key_type())?.1;
     secrets.insert(signing_did1_secret.clone()).await;
+    stats.update_keys_generated += 1;
 
     // Generate next_key_hashes
     let next_key1 = generate_did_key(args.key_type.key_type())?.1;
     secrets.insert(next_key1.clone()).await;
     let next_key2 = generate_did_key(args.key_type.key_type())?.1;
     secrets.insert(next_key2.clone()).await;
+    stats.update_keys_generated += 2;
 
     // Generate witnesses
     let witness = if args.witnesses > 0 {
@@ -423,6 +544,7 @@ async fn generate_did(
                 id: Multibase::new(w_did),
             });
         }
+        stats.witness_keys_generated += u64::from(args.witnesses);
 
         Some(Witnesses::Value {
             threshold: args.witnesses,
@@ -458,7 +580,7 @@ async fn generate_did(
         .await?;
 
     // Witness LogEntry
-    witness_log_entry(didwebvh, secrets).await?;
+    witness_log_entry(didwebvh, secrets, stats).await?;
 
     Ok(vec![next_key1, next_key2])
 }
@@ -466,6 +588,7 @@ async fn generate_did(
 async fn witness_log_entry(
     didwebvh: &mut DIDWebVHState,
     secrets: &SimpleSecretsResolver,
+    stats: &mut Stats,
 ) -> Result<()> {
     let (log_entries, witness_proofs) = didwebvh.log_entries_and_witness_proofs_mut();
     let log_entry = log_entries
@@ -508,6 +631,7 @@ async fn witness_log_entry(
         witness_proofs
             .add_proof(log_entry.get_version_id(), &proof, false)
             .map_err(|e| anyhow!("Error adding proof: {e}"))?;
+        stats.proofs_created += 1;
     }
 
     Ok(())
@@ -516,6 +640,7 @@ async fn witness_log_entry(
 async fn create_log_entry(
     didwebvh: &mut DIDWebVHState,
     secrets: &mut SimpleSecretsResolver,
+    stats: &mut Stats,
     previous_keys: &[Secret],
     count: u32,
     args: &Args,
@@ -534,6 +659,7 @@ async fn create_log_entry(
     secrets.insert(next_key1.clone()).await;
     let next_key2 = generate_did_key(args.key_type.key_type())?.1;
     secrets.insert(next_key2.clone()).await;
+    stats.update_keys_generated += 2;
 
     new_params.next_key_hashes = Some(Arc::new(vec![
         Multibase::new(next_key1.get_public_keymultibase_hash()?),
@@ -549,12 +675,13 @@ async fn create_log_entry(
 
     // Swap a witness node?
     if args.witnesses > 0 && count % 6 == 3 {
-        swap_witness(&mut new_params, secrets, args).await?;
+        swap_witness(&mut new_params, secrets, stats, args).await?;
     }
 
     // Swap a watcher node?
     if count.is_multiple_of(6) {
         swap_watcher(&mut new_params)?;
+        stats.watcher_swaps += 1;
     }
 
     let _ = didwebvh
@@ -569,7 +696,7 @@ async fn create_log_entry(
         .await?;
 
     // Witness LogEntry
-    witness_log_entry(didwebvh, secrets).await?;
+    witness_log_entry(didwebvh, secrets, stats).await?;
 
     Ok(vec![next_key1, next_key2])
 }
@@ -577,6 +704,7 @@ async fn create_log_entry(
 async fn swap_witness(
     params: &mut Parameters,
     secrets: &mut SimpleSecretsResolver,
+    stats: &mut Stats,
     args: &Args,
 ) -> Result<()> {
     // Pick a random witness and remove it
@@ -601,6 +729,8 @@ async fn swap_witness(
 
     let (new_witness_did, secret) = generate_did_key(args.key_type.key_type())?;
     secrets.insert(secret.clone()).await;
+    stats.witness_keys_generated += 1;
+    stats.witness_swaps += 1;
 
     new_witnesses.push(Witness {
         id: Multibase::new(new_witness_did),

--- a/src/did_web.rs
+++ b/src/did_web.rs
@@ -322,9 +322,11 @@ mod tests {
         assert!(also_known_as.contains(&"did:webvh:acme1234:affinidi.com".to_string()));
     }
 
-    /// Implicit services are emitted with relative-fragment IDs (`#files`,
-    /// `#whois`) and the `#files` `serviceEndpoint` has no trailing slash.
-    /// Matches the didwebvh-test-suite reference output and didwebvh-ts.
+    /// Implicit services use absolute IDs (`<did>#files`, `<did>#whois`) so
+    /// the resolved did:web document satisfies DID Core 1.0 §5.4. The
+    /// `did:webvh:<scid>:` prefix is rewritten to `did:web:` by
+    /// `to_web_did`, so the IDs land as `did:web:<host>#…`. The `#files`
+    /// `serviceEndpoint` has no trailing slash.
     #[test]
     fn test_services_none() {
         let old_state = json!({"id": "did:webvh:acme1234:affinidi.com"});
@@ -344,14 +346,14 @@ mod tests {
         assert_eq!(
             services[0],
             Service {
-                id: "#files".to_string(),
+                id: "did:web:affinidi.com#files".to_string(),
                 service_endpoint: "https://affinidi.com".to_string(),
             }
         );
         assert_eq!(
             services[1],
             Service {
-                id: "#whois".to_string(),
+                id: "did:web:affinidi.com#whois".to_string(),
                 service_endpoint: "https://affinidi.com/whois.vp".to_string(),
             }
         );
@@ -385,7 +387,8 @@ mod tests {
         assert_eq!(replace_webvh_prefix(input), input);
     }
 
-    /// Path-bearing DID: implicit services still use relative IDs, and the
+    /// Path-bearing DID: implicit services use absolute IDs that, after the
+    /// webvh→web prefix rewrite, become `did:web:<host>:<path>#…`. The
     /// `#files` endpoint drops its trailing slash to match the test-suite
     /// convention.
     #[test]
@@ -406,14 +409,14 @@ mod tests {
         assert_eq!(
             services[0],
             Service {
-                id: "#files".to_string(),
+                id: "did:web:affinidi.com:custom:path#files".to_string(),
                 service_endpoint: "https://affinidi.com/custom/path".to_string(),
             }
         );
         assert_eq!(
             services[1],
             Service {
-                id: "#whois".to_string(),
+                id: "did:web:affinidi.com:custom:path#whois".to_string(),
                 service_endpoint: "https://affinidi.com/custom/path/whois.vp".to_string(),
             }
         );

--- a/src/resolve/implicit.rs
+++ b/src/resolve/implicit.rs
@@ -12,11 +12,17 @@
 //!
 //! ## Format
 //!
-//! Both implicit services are emitted with **relative-fragment IDs** (`"#files"`
-//! / `"#whois"`) and in **`#files` then `#whois` order**, matching the
-//! didwebvh-test-suite reference output (and the didwebvh-ts reference
-//! implementation). The `#files` `serviceEndpoint` is the DID's HTTP base URL
-//! with any trailing `/` removed.
+//! Both implicit services are emitted with **absolute IDs**
+//! (`"<did>#files"` / `"<did>#whois"`) in **`#files` then `#whois` order**.
+//! W3C DID Core 1.0 §5.4 requires service `id` to be a URI per RFC 3986
+//! (which mandates a scheme); a fragment-only relative reference such as
+//! `"#files"` is a URI-reference, not a URI, and is rejected by typed
+//! DID-Document parsers (including `affinidi-did-common::DIDDocument`,
+//! whose service `id` field is `url::Url`). Earlier versions emitted the
+//! relative form to match didwebvh-test-suite / didwebvh-ts byte output;
+//! that was changed in 0.5.2 to make resolution outputs parseable by
+//! spec-compliant consumers. The `#files` `serviceEndpoint` still has any
+//! trailing `/` removed.
 //!
 //! ## Hash safety
 //!
@@ -56,7 +62,10 @@ pub(crate) fn update_implicit_services(
         // There are no services, add the implicit services in spec order
         ensure_object_mut(new_state)?.insert(
             "service".to_string(),
-            Value::Array(vec![get_service_files(&url)?, get_service_whois(&url)?]),
+            Value::Array(vec![
+                get_service_files(did_id, &url)?,
+                get_service_whois(did_id, &url)?,
+            ]),
         );
         return Ok(());
     };
@@ -87,10 +96,10 @@ pub(crate) fn update_implicit_services(
         let mut new_services = services.clone();
 
         if !has_files {
-            new_services.push(get_service_files(&url)?);
+            new_services.push(get_service_files(did_id, &url)?);
         }
         if !has_whois {
-            new_services.push(get_service_whois(&url)?);
+            new_services.push(get_service_whois(did_id, &url)?);
         }
 
         ensure_object_mut(new_state)?.insert("service".to_string(), Value::Array(new_services));
@@ -104,12 +113,13 @@ pub(crate) fn update_implicit_services(
 }
 
 /// `#whois` — `LinkedVerifiablePresentation` service pointing at the DID's
-/// `whois.vp`. ID is emitted as a relative fragment to match the
-/// didwebvh-test-suite reference output.
-fn get_service_whois(url: &WebVHURL) -> Result<Value, DIDWebVHError> {
+/// `whois.vp`. ID is emitted as the absolute form `<did>#whois` so the
+/// resolved document satisfies DID Core 1.0 §5.4 (service `id` MUST be a
+/// URI per RFC 3986).
+fn get_service_whois(did_id: &str, url: &WebVHURL) -> Result<Value, DIDWebVHError> {
     Ok(json!({
         "@context": "https://identity.foundation/linked-vp/contexts/v1",
-        "id": "#whois",
+        "id": format!("{did_id}#whois"),
         "type": "LinkedVerifiablePresentation",
         "serviceEndpoint": url.get_http_whois_url()?
     }))
@@ -117,14 +127,16 @@ fn get_service_whois(url: &WebVHURL) -> Result<Value, DIDWebVHError> {
 
 /// `#files` — `relativeRef` service pointing at the DID's HTTP base URL.
 ///
-/// The base URL is emitted **without** a trailing `/`. `Url::to_string()`
-/// always appends `/` to a host-only URL, but the test-suite reference (and
-/// didwebvh-ts) emit `https://example.com`, not `https://example.com/`.
-fn get_service_files(url: &WebVHURL) -> Result<Value, DIDWebVHError> {
+/// ID is emitted as the absolute form `<did>#files` for spec compliance
+/// (DID Core 1.0 §5.4). The base URL is emitted **without** a trailing
+/// `/`. `Url::to_string()` always appends `/` to a host-only URL, but the
+/// test-suite reference (and didwebvh-ts) emit `https://example.com`, not
+/// `https://example.com/`.
+fn get_service_files(did_id: &str, url: &WebVHURL) -> Result<Value, DIDWebVHError> {
     let endpoint = url.get_http_files_url()?.to_string();
     let endpoint = endpoint.strip_suffix('/').unwrap_or(&endpoint);
     Ok(json!({
-        "id": "#files",
+        "id": format!("{did_id}#files"),
         "type": "relativeRef",
         "serviceEndpoint": endpoint
     }))
@@ -137,7 +149,8 @@ mod tests {
 
     /// Tests that when a DID Document has no services defined, both implicit
     /// services are automatically added in spec order: `#files` first, then
-    /// `#whois`. IDs are emitted as relative fragments.
+    /// `#whois`. IDs are emitted in absolute form so the document satisfies
+    /// DID Core 1.0 §5.4.
     #[test]
     fn test_no_services_adds_both() {
         let mut state = json!({"id": "did:webvh:scid123:example.com"});
@@ -145,8 +158,14 @@ mod tests {
         let services = state["service"].as_array().unwrap();
         assert_eq!(services.len(), 2);
         // Order matters for JCS: #files MUST come before #whois.
-        assert_eq!(services[0]["id"].as_str(), Some("#files"));
-        assert_eq!(services[1]["id"].as_str(), Some("#whois"));
+        assert_eq!(
+            services[0]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#files")
+        );
+        assert_eq!(
+            services[1]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#whois")
+        );
     }
 
     /// Tests that when a DID Document has existing custom services but is missing
@@ -223,7 +242,7 @@ mod tests {
         let services = state["service"].as_array().unwrap();
         assert_eq!(services.len(), 2);
         let ids: Vec<&str> = services.iter().map(|s| s["id"].as_str().unwrap()).collect();
-        assert!(ids.contains(&"#files"));
+        assert!(ids.contains(&"did:webvh:scid123:example.com#files"));
     }
 
     /// When only `#files` exists (absolute form), the missing `#whois` is
@@ -244,7 +263,7 @@ mod tests {
         let services = state["service"].as_array().unwrap();
         assert_eq!(services.len(), 2);
         let ids: Vec<&str> = services.iter().map(|s| s["id"].as_str().unwrap()).collect();
-        assert!(ids.contains(&"#whois"));
+        assert!(ids.contains(&"did:webvh:scid123:example.com#whois"));
     }
 
     /// Both relative-form (`"#whois"`) and absolute-form
@@ -299,8 +318,14 @@ mod tests {
         // 2 user services + 2 implicit services = 4
         assert_eq!(services.len(), 4);
         // Implicits are appended at the end in #files, #whois order.
-        assert_eq!(services[2]["id"].as_str(), Some("#files"));
-        assert_eq!(services[3]["id"].as_str(), Some("#whois"));
+        assert_eq!(
+            services[2]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#files")
+        );
+        assert_eq!(
+            services[3]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#whois")
+        );
     }
 
     /// `#files` `serviceEndpoint` must NOT have a trailing slash for a
@@ -310,7 +335,10 @@ mod tests {
         let mut state = json!({"id": "did:webvh:scid123:example.com"});
         update_implicit_services(None, &mut state, "did:webvh:scid123:example.com").unwrap();
         let files = &state["service"][0];
-        assert_eq!(files["id"].as_str(), Some("#files"));
+        assert_eq!(
+            files["id"].as_str(),
+            Some("did:webvh:scid123:example.com#files")
+        );
         assert_eq!(
             files["serviceEndpoint"].as_str(),
             Some("https://example.com")
@@ -328,12 +356,18 @@ mod tests {
         let mut state = json!({"id": did});
         update_implicit_services(None, &mut state, did).unwrap();
         let services = state["service"].as_array().unwrap();
-        assert_eq!(services[0]["id"].as_str(), Some("#files"));
+        assert_eq!(
+            services[0]["id"].as_str(),
+            Some("did:webvh:scid123:example.com:foo:bar#files")
+        );
         assert_eq!(
             services[0]["serviceEndpoint"].as_str(),
             Some("https://example.com/foo/bar")
         );
-        assert_eq!(services[1]["id"].as_str(), Some("#whois"));
+        assert_eq!(
+            services[1]["id"].as_str(),
+            Some("did:webvh:scid123:example.com:foo:bar#whois")
+        );
         assert_eq!(
             services[1]["serviceEndpoint"].as_str(),
             Some("https://example.com/foo/bar/whois.vp")
@@ -399,7 +433,13 @@ mod tests {
         assert_eq!(services.len(), 4);
         assert_eq!(services[0]["id"].as_str(), Some("#linked-domain"));
         assert_eq!(services[1]["id"].as_str(), Some("#messaging"));
-        assert_eq!(services[2]["id"].as_str(), Some("#files"));
-        assert_eq!(services[3]["id"].as_str(), Some("#whois"));
+        assert_eq!(
+            services[2]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#files")
+        );
+        assert_eq!(
+            services[3]["id"].as_str(),
+            Some("did:webvh:scid123:example.com#whois")
+        );
     }
 }

--- a/tests/test_suite_interop.rs
+++ b/tests/test_suite_interop.rs
@@ -71,13 +71,20 @@ async fn run(scenario: &str, assert_did_document: bool) {
     );
 
     if assert_did_document {
-        let resolved_doc = entry
+        let mut resolved_doc = entry
             .get_did_document()
             .unwrap_or_else(|e| panic!("{scenario}: get_did_document failed: {e:?}"));
-        let expected_doc = expected
+        let mut expected_doc = expected
             .pointer("/didDocument")
             .cloned()
             .unwrap_or_else(|| panic!("{scenario}: expected.didDocument missing"));
+        // didwebvh-test-suite fixtures emit implicit `#files`/`#whois` with
+        // relative-fragment IDs; this resolver emits the absolute form
+        // (`<did>#files` / `<did>#whois`) for DID Core 1.0 §5.4 compliance.
+        // Normalise both sides to absolute before comparing so we test
+        // semantic equality rather than byte-for-byte parity.
+        normalise_implicit_service_ids(&mut resolved_doc, &did);
+        normalise_implicit_service_ids(&mut expected_doc, &did);
         assert_eq!(
             resolved_doc,
             expected_doc,
@@ -87,6 +94,27 @@ async fn run(scenario: &str, assert_did_document: bool) {
             resolved = serde_json::to_string_pretty(&resolved_doc).unwrap(),
             expected = serde_json::to_string_pretty(&expected_doc).unwrap(),
         );
+    }
+}
+
+/// Rewrites `service[].id` values of `"#files"`/`"#whois"` to their
+/// absolute form `"<did>#files"`/`"<did>#whois"`. Only the two implicit
+/// service names are touched — user-supplied relative IDs (e.g.
+/// `"#linked-domain"`) are left alone, matching the resolver's own
+/// normalisation policy.
+fn normalise_implicit_service_ids(doc: &mut Value, did: &str) {
+    let Some(services) = doc.get_mut("service").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+    for service in services {
+        let Some(id) = service.get_mut("id") else {
+            continue;
+        };
+        if id == "#files" {
+            *id = Value::String(format!("{did}#files"));
+        } else if id == "#whois" {
+            *id = Value::String(format!("{did}#whois"));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Spec compliance fix:** implicit `#files`/`#whois` services now use absolute-URI IDs (`<did>#files`/`<did>#whois`) per W3C DID Core 1.0 §5.4. The previous relative-fragment form was rejected by typed parsers (notably `affinidi-did-common::DIDDocument`) with `relative URL without a base: '#files'`, breaking real-world resolution flows.
- **PQC example fixes:** `examples/generate_history.rs` now wires up `WitnessVerifyOptions::with_extra_allowed_suite` so `--key-type ml-dsa-44` validates end-to-end, no longer panics on `--witnesses 0`, and stops loading a stale `did-witness.json` when run with no witnesses.
- **New run-summary stats** in `generate_history`: keys generated (split into update vs witness), witness/watcher swaps, witness proofs created and after optimisation, and verification load totals.
- **Version bump:** 0.5.1 → 0.5.2 (see `CHANGELOG.md`).

## Why the spec-compliance flip

`#files` is a valid URI-reference but **not** a URI per RFC 3986 — RFC 3986 requires a scheme. DID Core 1.0 §5.4 says service `id` "MUST be a URI conforming to [RFC3986]", so the relative form was technically non-conformant. didwebvh-test-suite and didwebvh-ts emit relative IDs, but that's an inherited laxness: JS doesn't type-check service IDs, so the reference impl never noticed. Typed Rust consumers do. The duplicate-detection logic still recognises both forms so user-supplied relative IDs aren't double-injected. The interop runner now normalises both expected and resolved docs before comparison so the existing fixtures still pass.

## Commits

1. `fix(examples): widen witness verify suites for PQC` — original ML-DSA-44 validation fix
2. `feat(examples): add run-summary stats` — keys/proofs/swaps counters
3. `fix(examples): handle --witnesses 0` — panic + stale-file fix
4. `fix: emit absolute IDs for implicit #files/#whois services (0.5.2)` — spec-compliance bump

## Test plan

- [x] `cargo test --all-features` — 473 tests pass (411 unit + integration + interop)
- [x] `cargo clippy --all-features --tests --examples --lib -- -D warnings` clean
- [x] `cargo run --release --features experimental-pqc --example generate_history -- --key-type ml-dsa-44 --count 12` validates end-to-end, summary block accurate
- [x] `cargo run --release --features experimental-pqc --example generate_history -- --witnesses 0 --count 6` no panic, summary clean
- [x] Manually verified the resolved DID Document parses cleanly when fed through `serde_json::from_value::<DIDDocument>` consumers
- [ ] Reviewer to sanity-check the test-suite normalisation step in `tests/test_suite_interop.rs` — the fixtures themselves are unchanged, only the comparison is normalised