### PR TITLE
security: 15 patches from cross-impl audit + v0.5.3 (closes #39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # --tests + --examples covers the shipping code without tripping
       # the nightly-only did_benchmarks_nightly bench (uses #![feature(test)]).
-      #
-      # `experimental-pqc` is deliberately excluded: it enables
-      # `affinidi-crypto/post-quantum` whose 0.1.5 release imports
-      # `ml_dsa::KeyGen` from the root, but `ml-dsa 0.1.0` (stable release)
-      # moved that symbol — pure upstream API churn that has nothing to do
-      # with didwebvh-rs. The feature is marked experimental in Cargo.toml
-      # for exactly this reason. Re-include once upstream `affinidi-crypto`
-      # publishes a release compatible with `ml-dsa >= 0.1.0`.
-      - run: cargo clippy --features ssi,rustls,cli --tests --examples -- -D warnings
+      - run: cargo clippy --all-features --tests --examples -- -D warnings
 
   test:
     name: Test
@@ -49,9 +41,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
-      # Excludes `experimental-pqc` (upstream affinidi-crypto/ml-dsa breakage).
-      # See the same exclusion + rationale in the Clippy job above.
-      - run: cargo test --features ssi,rustls,cli
+      - run: cargo test --all-features
 
   msrv:
     name: MSRV (1.95.0)
@@ -62,9 +52,7 @@ jobs:
         with:
           toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
-      # Excludes `experimental-pqc` (upstream affinidi-crypto/ml-dsa breakage).
-      # See the Clippy job for the full rationale.
-      - run: cargo check --features ssi,rustls,cli
+      - run: cargo check --all-features
 
   audit:
     name: Security Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,13 @@ jobs:
       - run: cargo test --all-features
 
   msrv:
-    name: MSRV (1.94.0)
+    name: MSRV (1.95.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # --tests + --examples covers the shipping code without tripping
       # the nightly-only did_benchmarks_nightly bench (uses #![feature(test)]).
-      - run: cargo clippy --all-features --tests --examples -- -D warnings
+      #
+      # `experimental-pqc` is deliberately excluded: it enables
+      # `affinidi-crypto/post-quantum` whose 0.1.5 release imports
+      # `ml_dsa::KeyGen` from the root, but `ml-dsa 0.1.0` (stable release)
+      # moved that symbol — pure upstream API churn that has nothing to do
+      # with didwebvh-rs. The feature is marked experimental in Cargo.toml
+      # for exactly this reason. Re-include once upstream `affinidi-crypto`
+      # publishes a release compatible with `ml-dsa >= 0.1.0`.
+      - run: cargo clippy --features ssi,rustls,cli --tests --examples -- -D warnings
 
   test:
     name: Test
@@ -41,7 +49,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+      # Excludes `experimental-pqc` (upstream affinidi-crypto/ml-dsa breakage).
+      # See the same exclusion + rationale in the Clippy job above.
+      - run: cargo test --features ssi,rustls,cli
 
   msrv:
     name: MSRV (1.95.0)
@@ -52,7 +62,9 @@ jobs:
         with:
           toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-features
+      # Excludes `experimental-pqc` (upstream affinidi-crypto/ml-dsa breakage).
+      # See the Clippy job for the full rationale.
+      - run: cargo check --features ssi,rustls,cli
 
   audit:
     name: Security Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,16 +74,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - run: cargo install cargo-audit
-      # Ignored advisories are all transitive via the optional `ssi`
-      # feature; the default build has zero advisories. Re-audit when
-      # upstream `ssi` drops the affected dep chains.
-      # - RUSTSEC-2023-0071: rsa 0.6.1 (via ssi-jwk)
-      # - RUSTSEC-2024-0388: derivative unmaintained (via ssi-jwk)
-      # - RUSTSEC-2024-0370: proc-macro-error unmaintained (via did-tz)
-      # - RUSTSEC-2025-0134: rustls-pemfile unmaintained (via reqwest 0.11)
-      # - RUSTSEC-2021-0127: serde_cbor unmaintained (via ssi-vc-jose-cose)
+      # Ignored advisories are ALL transitive via the optional `ssi`
+      # feature; the default build has zero advisories. Reviewed and
+      # confirmed still warranted on every CI run.
+      #
+      # Vulnerabilities (advisories with severity):
+      # - RUSTSEC-2023-0071: rsa 0.6.1 Marvin Attack timing side-channel (via ssi-jwk)
       # - RUSTSEC-2026-0098: rustls-webpki 0.101.7 URI name constraints (via reqwest 0.11)
-      # - RUSTSEC-2026-0099: rustls-webpki 0.101.7 wildcard constraints (via reqwest 0.11)
+      # - RUSTSEC-2026-0099: rustls-webpki 0.101.7 wildcard name constraints (via reqwest 0.11)
+      # - RUSTSEC-2026-0104: rustls-webpki 0.101.7 CRL parse panic (via reqwest 0.11)
+      #
+      # Unmaintained warnings (no CVE, advisory category = "unmaintained"):
+      # - RUSTSEC-2021-0127: serde_cbor unmaintained (via ssi-vc-jose-cose)
+      # - RUSTSEC-2024-0370: proc-macro-error unmaintained (via did-tz)
+      # - RUSTSEC-2024-0388: derivative unmaintained (via ssi-jwk)
+      # - RUSTSEC-2025-0134: rustls-pemfile unmaintained (via reqwest 0.11)
+      #
+      # Re-audit when upstream `ssi` drops the affected dep chains
+      # (most are rooted in ssi-jwk / ssi-vc-jose-cose / reqwest 0.11).
       - run: >-
           cargo audit
           --ignore RUSTSEC-2023-0071
@@ -93,3 +101,4 @@ jobs:
           --ignore RUSTSEC-2021-0127
           --ignore RUSTSEC-2026-0098
           --ignore RUSTSEC-2026-0099
+          --ignore RUSTSEC-2026-0104

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,7 @@ dependencies = [
  "dialoguer",
  "format_num",
  "getrandom 0.4.2",
+ "percent-encoding",
  "proptest",
  "rand 0.10.1",
  "reqwest 0.13.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c0fb004d079a20c37bd74bfb1d5be7122aaec25dcc6265c684e46b8b7b26c1"
+checksum = "63cac399b6d7547a9af38375e596dc6df60d206d02eec037e69f30600a37dac6"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5939,7 +5939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,15 +312,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
@@ -629,9 +629,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -647,12 +647,6 @@ checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
 dependencies = [
  "slab",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -720,13 +714,12 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
  "multibase 0.9.2",
  "multihash",
- "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.8.0",
@@ -1030,11 +1023,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1200,15 +1195,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1216,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.117",
@@ -1450,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -1469,11 +1464,11 @@ dependencies = [
  "getrandom 0.4.2",
  "proptest",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "serde_with 3.18.0",
+ "serde_with 3.20.0",
  "sha2 0.11.0",
  "ssi",
  "thiserror 2.0.18",
@@ -1507,13 +1502,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1614,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1987,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2060,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2112,7 +2107,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2184,10 +2179,11 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
+ "ctutils",
  "typenum",
  "zeroize",
 ]
@@ -2226,7 +2222,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2261,7 +2257,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2452,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2492,7 +2488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2547,16 +2543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,27 +2565,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2633,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2968,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -3132,27 +3123,28 @@ dependencies = [
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.8"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b2bb0ad6fa2b40396775bd56f51345171490fef993f46f91a876ecdbdaea55"
+checksum = "b67011732d2747886c7b64f2eceef9d6eb2645a0aa528a26828b949ece257285"
 dependencies = [
  "const-oid 0.10.2",
+ "crypto-common 0.2.2",
  "ctutils",
  "hybrid-array",
  "module-lattice",
- "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.1",
- "sha3 0.11.0",
- "signature 3.0.0-rc.10",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
  "zeroize",
 ]
 
 [[package]]
 name = "module-lattice"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eb3faeaecbd14b0b2a917c1b4d0c035097a9c559b0bed85c2cdd032bc8faa"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
+ "ctutils",
  "hybrid-array",
  "num-traits",
  "zeroize",
@@ -3189,11 +3181,10 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "serde",
  "unsigned-varint 0.8.0",
 ]
@@ -3213,15 +3204,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3271,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3363,15 +3345,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3404,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3534,18 +3515,18 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3592,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -3795,7 +3776,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3816,7 +3797,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -4145,7 +4126,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4177,15 +4158,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4200,7 +4181,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper 1.0.2",
@@ -4302,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec 0.7.6",
  "borsh",
@@ -4359,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4394,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4404,16 +4385,16 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -4680,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4743,11 +4724,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4756,7 +4738,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.18.0",
+ "serde_with_macros 3.20.0",
  "time",
 ]
 
@@ -4786,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4828,7 +4810,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4847,8 +4829,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4884,11 +4877,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
  "rand_core 0.10.1",
 ]
 
@@ -4897,6 +4890,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -4934,19 +4937,19 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f6f9b5317f06189671584c283b3f26339b89c97f21b5c50ae24aec397304a7"
+checksum = "371c02fe34044d8866ddf7cb0e8204a87ef31a39f0408bed41c4253ea9dd61ed"
 dependencies = [
  "const-oid 0.10.2",
- "digest 0.11.2",
+ "digest 0.11.3",
  "hmac 0.13.0",
  "hybrid-array",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "rand_core 0.10.1",
  "sha2 0.11.0",
  "sha3 0.11.0",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "typenum",
  "zerocopy",
  "zeroize",
@@ -5023,6 +5026,12 @@ dependencies = [
  "base64ct",
  "der 0.8.0",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sshkeys"
@@ -6061,9 +6070,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6111,7 +6120,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -6175,20 +6184,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6486,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6499,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6509,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6519,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6532,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -6575,9 +6584,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6711,15 +6720,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6752,21 +6752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6819,12 +6804,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6843,12 +6822,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6864,12 +6837,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6903,12 +6870,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6924,12 +6885,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6951,12 +6906,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6972,12 +6921,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6999,9 +6942,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7232,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.2"
+version = "0.5.3"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"
@@ -55,7 +55,7 @@ reqwest = { version = "0.13", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_json_canonicalizer = "0.3"
-serde_with = "3.18"
+serde_with = "3.20"
 sha2 = "0.11"
 ssi = { version = "0.16", features = ["secp384r1"], optional = true }
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ssi", "did", "webvh", "verifiable"]
 publish = true
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 
 # `getrandom` is listed in [dependencies] with `features = ["wasm_js"]`
 # but isn't directly imported — the purpose is to enable the `wasm_js`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ssi = { version = "0.16", features = ["secp384r1"], optional = true }
 thiserror = "2.0"
 tokio = { version = "1" }
 tracing = { version = "0.1" }
+percent-encoding = "2.3"
 url = "2.5"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 

--- a/src/did_web.rs
+++ b/src/did_web.rs
@@ -26,10 +26,13 @@ impl DIDWebVHState {
     /// Takes a did:webvh ID and converts it to a did:web ID
     pub fn convert_webvh_id_to_web_id(id: &str) -> String {
         // input: did:webvh:<SCID>:<path>
+        // `id` is taken from the DID document's `state["id"]`, i.e. attacker-
+        // controlled, so a malformed value with fewer than three ':' segments
+        // must degrade to a useless-but-safe result rather than panic.
         let parts: Vec<&str> = id.split(':').collect();
         let mut new_did = String::new();
         new_did.push_str("did:web");
-        for p in parts[3..].iter() {
+        for p in parts.get(3..).unwrap_or_default() {
             new_did.push(':');
             new_did.push_str(p);
         }
@@ -356,6 +359,20 @@ mod tests {
                 id: "did:web:affinidi.com#whois".to_string(),
                 service_endpoint: "https://affinidi.com/whois.vp".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn test_convert_webvh_to_web_malformed_no_panic() {
+        // state["id"] is attacker-controlled; fewer than three ':' segments
+        // used to panic on `parts[3..]`. It must now return a (useless but
+        // harmless) bare "did:web" instead of crashing the resolver.
+        assert_eq!(DIDWebVHState::convert_webvh_id_to_web_id(""), "did:web");
+        assert_eq!(DIDWebVHState::convert_webvh_id_to_web_id("x"), "did:web");
+        assert_eq!(DIDWebVHState::convert_webvh_id_to_web_id("a:b"), "did:web");
+        assert_eq!(
+            DIDWebVHState::convert_webvh_id_to_web_id("did:webvh:scid"),
+            "did:web"
         );
     }
 

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -72,6 +72,19 @@ impl LogEntry {
             )));
         }
 
+        // didwebvh 1.0 mandates eddsa-jcs-2022 for the controller's log-entry
+        // proof. Enforcing it here (as we already do for witness proofs via
+        // enforce_witness_proof_shape) blocks algorithm-substitution: the key
+        // bytes are decoded from did:key independently of the suite, so a
+        // proof that selects a different suite would otherwise feed those
+        // bytes into a verifier they were not generated for.
+        if proof.cryptosuite != affinidi_data_integrity::crypto_suites::CryptoSuite::EddsaJcs2022 {
+            return Err(DIDWebVHError::ValidationError(format!(
+                "Invalid cryptosuite {:?}: log entry proofs must use eddsa-jcs-2022",
+                proof.cryptosuite
+            )));
+        }
+
         // Ensure the Parameters are correctly setup
         let parameters = match self.get_parameters().validate(previous_parameters) {
             Ok(params) => params,
@@ -431,6 +444,35 @@ mod tests {
                 "Expected assertionMethod error for proofPurpose '{bad_purpose}', got: {result:?}",
             );
         }
+    }
+
+    /// Tests that verify_log_entry rejects a proof whose cryptosuite is not
+    /// eddsa-jcs-2022. The spec mandates this suite; accepting eddsa-rdfc-2022
+    /// would feed the same did:key bytes into a different canonicalization
+    /// pipeline and break interop/signature-domain separation.
+    #[test]
+    fn test_invalid_cryptosuite_rejected() {
+        let entry = LogEntry::Spec1_0(LogEntry1_0 {
+            version_id: "1-abcdef".to_string(),
+            version_time: Utc::now().fixed_offset(),
+            parameters: Parameters1_0::default(),
+            state: json!({}),
+            proof: vec![DataIntegrityProof {
+                type_: "DataIntegrityProof".to_string(),
+                cryptosuite: CryptoSuite::EddsaRdfc2022,
+                created: None,
+                verification_method: "did:key:z6Mk#z6Mk".to_string(),
+                proof_purpose: "assertionMethod".to_string(),
+                proof_value: Some("zDummy".to_string()),
+                context: None,
+            }],
+        });
+
+        let result = entry.verify_log_entry(None, None);
+        assert!(
+            matches!(result, Err(DIDWebVHError::ValidationError(ref msg)) if msg.contains("eddsa-jcs-2022")),
+            "Expected eddsa-jcs-2022 error, got: {result:?}",
+        );
     }
 
     /// Tests that verify_portability passes when the DID document id has not

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -195,11 +195,21 @@ impl LogEntry {
             return false;
         }
 
-        if let Some((_, key)) = proof_key.split_once('#') {
-            authorized_keys.iter().any(|f| f.as_str() == key)
-        } else {
-            false
+        // The proof's verificationMethod must be exactly `did:key:{mb}#{mb}` for an
+        // authorized multibase `{mb}`. Signature verification later decodes the public
+        // key from the DID *body* (before `#`) via `resolve_did_key`, so checking only
+        // the fragment would let `did:key:<attacker>#<authorized>` pass authorization
+        // here while verifying against the attacker's key — a full forgery.
+        let Some((did, fragment)) = proof_key.split_once('#') else {
+            return false;
+        };
+        let Some(body) = did.strip_prefix("did:key:") else {
+            return false;
+        };
+        if body != fragment {
+            return false;
         }
+        authorized_keys.iter().any(|f| f.as_str() == body)
     }
 
     /// Checks the version ID of a LogEntry against the previous LogEntry
@@ -717,6 +727,40 @@ mod tests {
         assert!(LogEntry::check_signing_key_authorized(
             &Arc::new(authorized_keys),
             "did:key:z6Mkr46vzpmne5FJTE1TgRHrWkoc5j9Kb1suMYtxkdvgMu15#z6Mkr46vzpmne5FJTE1TgRHrWkoc5j9Kb1suMYtxkdvgMu15"
+        ));
+    }
+
+    /// Regression: a verificationMethod whose fragment names an authorized key but whose
+    /// did:key body names a *different* key must be rejected. Signature verification
+    /// decodes the public key from the body, so accepting this would allow anyone to
+    /// forge log entries by signing with their own key and pointing the fragment at an
+    /// authorized one.
+    #[test]
+    fn test_authorized_keys_mismatched_body_and_fragment_rejected() {
+        let authorized = "z6Mkr46vzpmne5FJTE1TgRHrWkoc5j9Kb1suMYtxkdvgMu15";
+        let attacker = "z6MktKQzZyzDTccPxQR1vQfYHrXUmyDkBkJ7nFjTuqmas5Z2";
+        let authorized_keys: Vec<Multibase> = vec![Multibase::new(authorized)];
+
+        assert!(!LogEntry::check_signing_key_authorized(
+            &Arc::new(authorized_keys.clone()),
+            &format!("did:key:{attacker}#{authorized}"),
+        ));
+        // and the mirror: authorized body with attacker fragment must also fail
+        assert!(!LogEntry::check_signing_key_authorized(
+            &Arc::new(authorized_keys),
+            &format!("did:key:{authorized}#{attacker}"),
+        ));
+    }
+
+    /// A verificationMethod that isn't a did:key URI at all must be rejected even if
+    /// its fragment matches an authorized key.
+    #[test]
+    fn test_authorized_keys_non_did_key_rejected() {
+        let authorized = "z6Mkr46vzpmne5FJTE1TgRHrWkoc5j9Kb1suMYtxkdvgMu15";
+        let authorized_keys: Vec<Multibase> = vec![Multibase::new(authorized)];
+        assert!(!LogEntry::check_signing_key_authorized(
+            &Arc::new(authorized_keys),
+            &format!("did:web:example.com#{authorized}"),
         ));
     }
 

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -78,9 +78,25 @@ impl LogEntry {
         // bytes are decoded from did:key independently of the suite, so a
         // proof that selects a different suite would otherwise feed those
         // bytes into a verifier they were not generated for.
-        if proof.cryptosuite != affinidi_data_integrity::crypto_suites::CryptoSuite::EddsaJcs2022 {
+        //
+        // The `experimental-pqc` feature widens the accepted set to include
+        // the JCS-canonicalized PQC variants from W3C `di-quantum-safe` v0.3
+        // (not yet in didwebvh 1.0 — opt-in build flag). RDFC variants are
+        // still rejected: didwebvh 1.0 mandates JCS canonicalization, and
+        // accepting an RDFC suite would re-introduce the algorithm-
+        // substitution risk this check exists to close.
+        let cryptosuite_ok = match proof.cryptosuite {
+            affinidi_data_integrity::crypto_suites::CryptoSuite::EddsaJcs2022 => true,
+            #[cfg(feature = "experimental-pqc")]
+            affinidi_data_integrity::crypto_suites::CryptoSuite::MlDsa44Jcs2024
+            | affinidi_data_integrity::crypto_suites::CryptoSuite::SlhDsa128Jcs2024 => true,
+            _ => false,
+        };
+        if !cryptosuite_ok {
             return Err(DIDWebVHError::ValidationError(format!(
-                "Invalid cryptosuite {:?}: log entry proofs must use eddsa-jcs-2022",
+                "Invalid cryptosuite {:?}: log entry proofs must use eddsa-jcs-2022 \
+                 (or, with the `experimental-pqc` build feature, a JCS-canonicalized \
+                 PQC suite from W3C di-quantum-safe v0.3)",
                 proof.cryptosuite
             )));
         }

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -278,6 +278,26 @@ impl LogEntry {
         let current_id = self.get_state().get("id").and_then(|v| v.as_str());
         let previous_id = previous.get_state().get("id").and_then(|v| v.as_str());
 
+        // Portability lets the host/path change; the SCID never does. Without
+        // this, a portable DID could set entry N's state.id to
+        // `did:webvh:<anything>:new-host` (with the old DID in alsoKnownAs)
+        // and resolve_state would then accept a request for that arbitrary
+        // SCID — the same self-certifying bypass verify_scid() closes for the
+        // genesis entry, reopened at N>1. parameters.scid is carried forward
+        // unchanged from genesis, so it is the authoritative anchor.
+        if let Some(current) = current_id {
+            let scid = parameters.scid.as_deref().map(String::as_str);
+            let doc_scid = current
+                .strip_prefix("did:webvh:")
+                .and_then(|rest| rest.split_once(':'))
+                .map(|(s, _)| s);
+            if doc_scid.is_none() || doc_scid != scid {
+                return Err(DIDWebVHError::ValidationError(format!(
+                    "DID document id SCID ({doc_scid:?}) does not match parameters.scid ({scid:?})",
+                )));
+            }
+        }
+
         if let (Some(current), Some(previous_did)) = (current_id, previous_id)
             && current != previous_did
         {
@@ -421,6 +441,18 @@ mod tests {
         })
     }
 
+    /// Validated-parameters fixture for `verify_portability` tests: `scid` is
+    /// set to match the `did:webvh:abc123:...` doc ids used throughout, so the
+    /// SCID-immutability check passes and the test exercises only the
+    /// portability rule it names.
+    fn portability_params(portable: Option<bool>) -> Parameters {
+        Parameters {
+            portable,
+            scid: Some(Arc::new("abc123".to_string())),
+            ..Default::default()
+        }
+    }
+
     /// Helper to create a minimal Spec1_0 LogEntry with a specific timestamp.
     /// Uses a fixed versionId of "1-abc123", a default DID document state with a
     /// valid id field, default parameters, and an empty proof list. Useful for tests
@@ -507,10 +539,7 @@ mod tests {
         // Same DID id between entries, portable=false → should pass
         let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
         let current = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
-        let params = Parameters {
-            portable: Some(false),
-            ..Default::default()
-        };
+        let params = portability_params(Some(false));
 
         assert!(current.verify_portability(&previous, &params).is_ok());
     }
@@ -525,10 +554,7 @@ mod tests {
         // DID id changed, portable=false → must fail
         let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
         let current = make_log_entry(json!({"id": "did:webvh:abc123:newdomain.com"}));
-        let params = Parameters {
-            portable: Some(false),
-            ..Default::default()
-        };
+        let params = portability_params(Some(false));
 
         let result = current.verify_portability(&previous, &params);
         assert!(result.is_err());
@@ -550,10 +576,7 @@ mod tests {
         // DID id changed, portable=None (defaults to false) → must fail
         let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
         let current = make_log_entry(json!({"id": "did:webvh:abc123:newdomain.com"}));
-        let params = Parameters {
-            portable: None,
-            ..Default::default()
-        };
+        let params = portability_params(None);
 
         let result = current.verify_portability(&previous, &params);
         assert!(result.is_err());
@@ -575,10 +598,7 @@ mod tests {
         // DID id changed, portable=true, but no alsoKnownAs → must fail
         let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
         let current = make_log_entry(json!({"id": "did:webvh:abc123:newdomain.com"}));
-        let params = Parameters {
-            portable: Some(true),
-            ..Default::default()
-        };
+        let params = portability_params(Some(true));
 
         let result = current.verify_portability(&previous, &params);
         assert!(result.is_err());
@@ -604,10 +624,7 @@ mod tests {
             "id": "did:webvh:abc123:newdomain.com",
             "alsoKnownAs": ["did:webvh:abc123:other.com"]
         }));
-        let params = Parameters {
-            portable: Some(true),
-            ..Default::default()
-        };
+        let params = portability_params(Some(true));
 
         let result = current.verify_portability(&previous, &params);
         assert!(result.is_err());
@@ -632,12 +649,31 @@ mod tests {
             "id": "did:webvh:abc123:newdomain.com",
             "alsoKnownAs": ["did:webvh:abc123:example.com"]
         }));
-        let params = Parameters {
-            portable: Some(true),
-            ..Default::default()
-        };
+        let params = portability_params(Some(true));
 
         assert!(current.verify_portability(&previous, &params).is_ok());
+    }
+
+    /// Regression: portability lets the host change, never the SCID. Before
+    /// this check a portable DID could set entry N's `state.id` to
+    /// `did:webvh:<anything>:new-host` (with the old DID in alsoKnownAs) and
+    /// pass — the same self-certifying bypass `verify_scid` closes for the
+    /// genesis, reopened at N>1. `parameters.scid` is the genesis hash carried
+    /// forward unchanged, so any entry whose doc-id SCID differs is rejected.
+    #[test]
+    fn test_portability_rejects_scid_change() {
+        let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
+        let current = make_log_entry(json!({
+            "id": "did:webvh:DIFFERENTSCID:newdomain.com",
+            "alsoKnownAs": ["did:webvh:abc123:example.com"]
+        }));
+        let params = portability_params(Some(true));
+
+        let err = current.verify_portability(&previous, &params).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match parameters.scid"),
+            "got: {err}"
+        );
     }
 
     /// Tests that verify_portability succeeds when the DID id has not changed,
@@ -650,10 +686,7 @@ mod tests {
         // Same DID id, portable=true → should pass (no move happened)
         let previous = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
         let current = make_log_entry(json!({"id": "did:webvh:abc123:example.com"}));
-        let params = Parameters {
-            portable: Some(true),
-            ..Default::default()
-        };
+        let params = portability_params(Some(true));
 
         assert!(current.verify_portability(&previous, &params).is_ok());
     }

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -367,6 +367,28 @@ impl LogEntry {
             )));
         }
 
+        // The check above proves `parameters.scid` is the genesis self-hash.
+        // It does NOT prove the SCID embedded in the DID document's `id` is
+        // that same value — `state["id"]` is attacker-authored and the
+        // string-replace above only targets `parameters.scid`. Without this
+        // check an attacker can set `state.id = "did:webvh:<anything>:host"`
+        // and `parameters.scid = <real-hash>`; verify_scid passes, and a
+        // resolver requesting `did:webvh:<anything>:host` matches it against
+        // `state["id"]` and accepts. The "self-certifying" in SCID would then
+        // certify nothing about the DID the user actually resolved.
+        let doc_scid = self
+            .get_state()
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(|id| id.strip_prefix("did:webvh:"))
+            .and_then(|rest| rest.split_once(':'))
+            .map(|(s, _)| s);
+        if doc_scid != Some(scid.as_str()) {
+            return Err(DIDWebVHError::ValidationError(format!(
+                "DID document id SCID ({doc_scid:?}) does not match parameters.scid ({scid})",
+            )));
+        }
+
         Ok(())
     }
 }

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -1086,8 +1086,9 @@ mod tests {
         };
         let err = current.validate(Some(&previous)).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("updateKeys must be provided when previous entry committed nextKeyHashes")
+            err.to_string().contains(
+                "updateKeys must be provided when previous entry committed nextKeyHashes"
+            )
         );
     }
 
@@ -1106,8 +1107,9 @@ mod tests {
         };
         let err = current.validate(Some(&previous)).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("updateKeys must not be empty when previous entry committed nextKeyHashes")
+            err.to_string().contains(
+                "updateKeys must not be empty when previous entry committed nextKeyHashes"
+            )
         );
     }
 

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -365,11 +365,30 @@ impl Parameters {
         if let Some(previous) = previous {
             match &self.update_keys {
                 None => {
-                    // If absent, keep current updateKeys
+                    // If absent, keep current updateKeys.
+                    // But when the *previous* entry committed nextKeyHashes, this
+                    // entry MUST present updateKeys that hash into that set.
+                    // Allowing absence here would let an attacker who compromised
+                    // an old update key sign this entry with it (the pre-rotation
+                    // branch in verify_log_entry self-authorises against
+                    // `parameters.active_update_keys`, which would inherit the old
+                    // keys unchanged) — defeating pre-rotation entirely.
+                    if pre_rotation_previous_value {
+                        return Err(DIDWebVHError::ParametersError(
+                            "updateKeys must be provided when previous entry committed nextKeyHashes (pre-rotation active)"
+                                .to_string(),
+                        ));
+                    }
                     new_parameters.active_update_keys = previous.active_update_keys.clone();
                 }
                 Some(update_keys) => {
                     if update_keys.is_empty() {
+                        if pre_rotation_previous_value {
+                            return Err(DIDWebVHError::ParametersError(
+                                "updateKeys must not be empty when previous entry committed nextKeyHashes (pre-rotation active)"
+                                    .to_string(),
+                            ));
+                        }
                         // If empty, turn off updateKeys
                         new_parameters.update_keys = Some(Arc::new(Vec::new()));
                         new_parameters.active_update_keys = previous.active_update_keys.clone();
@@ -1046,6 +1065,50 @@ mod tests {
         };
         let err = current.validate(Some(&previous)).unwrap_err();
         assert!(err.to_string().contains("nextKeyHashes cannot be absent"));
+    }
+
+    /// Security regression: when the previous entry committed nextKeyHashes,
+    /// the current entry MUST present updateKeys. Omitting them previously
+    /// caused active_update_keys to inherit the *old* keys unchanged, and
+    /// verify_log_entry's pre-rotation branch then authorized the proof
+    /// against those old keys — letting a compromised old key forge the next
+    /// entry and bypass pre-rotation entirely.
+    #[test]
+    fn validate_update_keys_absent_pre_rotation_active_error() {
+        let mut previous = validated_first_params();
+        previous.pre_rotation_active = true;
+        previous.next_key_hashes = Some(Arc::new(vec![Multibase::new("hash")]));
+
+        let current = Parameters {
+            next_key_hashes: Some(Arc::new(vec![Multibase::new("next-hash")])),
+            update_keys: None,
+            ..Default::default()
+        };
+        let err = current.validate(Some(&previous)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("updateKeys must be provided when previous entry committed nextKeyHashes")
+        );
+    }
+
+    /// Security regression: same bypass as above via an explicitly empty
+    /// updateKeys array instead of omission.
+    #[test]
+    fn validate_update_keys_empty_pre_rotation_active_error() {
+        let mut previous = validated_first_params();
+        previous.pre_rotation_active = true;
+        previous.next_key_hashes = Some(Arc::new(vec![Multibase::new("hash")]));
+
+        let current = Parameters {
+            next_key_hashes: Some(Arc::new(vec![])),
+            update_keys: Some(Arc::new(vec![])),
+            ..Default::default()
+        };
+        let err = current.validate(Some(&previous)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("updateKeys must not be empty when previous entry committed nextKeyHashes")
+        );
     }
 
     /// Given a previous entry with pre-rotation active and a current entry with empty nextKeyHashes,

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -459,6 +459,7 @@ impl DIDWebVHState {
 
                     let client = reqwest::ClientBuilder::new()
                         .timeout(network_timeout)
+                        .redirect(reqwest::redirect::Policy::none())
                         .build()
                         .map_err(|e| DIDWebVHError::NetworkError {
                             url: String::new(),

--- a/src/url.rs
+++ b/src/url.rs
@@ -394,9 +394,8 @@ impl WebVHURL {
             url_string.push_str(&format!("#{fragment}",));
         }
 
-        let url = Url::parse(&url_string).map_err(|err| {
-            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
-        })?;
+        let url = Url::parse(&url_string)
+            .map_err(|err| DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}")))?;
         Self::reject_ip_host(&url)?;
         Ok(url)
     }
@@ -414,9 +413,8 @@ impl WebVHURL {
             url_string.push_str("whois.vp");
         }
 
-        let url = Url::parse(&url_string).map_err(|err| {
-            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
-        })?;
+        let url = Url::parse(&url_string)
+            .map_err(|err| DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}")))?;
         Self::reject_ip_host(&url)?;
         Ok(url)
     }
@@ -433,9 +431,8 @@ impl WebVHURL {
             url_string.push_str(&self.path);
         }
 
-        let url = Url::parse(&url_string).map_err(|err| {
-            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
-        })?;
+        let url = Url::parse(&url_string)
+            .map_err(|err| DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}")))?;
         Self::reject_ip_host(&url)?;
         Ok(url)
     }

--- a/src/url.rs
+++ b/src/url.rs
@@ -103,7 +103,13 @@ impl WebVHURL {
 
         let scid = parts[0].to_string();
 
-        let (domain, port) = match parts[1].split_once("%3A") {
+        // Percent-encoding is case-insensitive (RFC 3986 §2.1). Matching only the
+        // uppercase form would leave `127.0.0.1%3a8080` as the "domain", which then
+        // slips past `reject_ip_address()` because it no longer parses as a bare IP.
+        let (domain, port) = match parts[1]
+            .split_once("%3A")
+            .or_else(|| parts[1].split_once("%3a"))
+        {
             Some((domain, port)) => {
                 let port = match port.parse::<u16>() {
                     Ok(port) => port,
@@ -504,6 +510,21 @@ mod tests {
     #[test]
     fn url_with_port() {
         assert!(WebVHURL::parse_did_url("did:webvh:scid:domain%3A8000").is_ok());
+    }
+
+    #[test]
+    fn url_with_lowercase_pct_port() -> Result<(), DIDWebVHError> {
+        let parsed = WebVHURL::parse_did_url("did:webvh:scid:domain%3a8000")?;
+        assert_eq!(parsed.domain, "domain");
+        assert_eq!(parsed.port, Some(8000));
+        Ok(())
+    }
+
+    #[test]
+    fn url_rejects_ipv4_with_lowercase_pct_port() {
+        // Previously slipped past reject_ip_address() because the unparsed
+        // `%3a8080` suffix stayed glued to the host.
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:127.0.0.1%3a8080").is_err());
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -132,8 +132,17 @@ impl WebVHURL {
             // These segments are joined with '/' into the HTTP path that the
             // resolver fetches. Reject anything that would let a crafted DID
             // escape its directory (`..`), collapse to the current dir (`.`),
-            // produce `//` (empty), or smuggle an extra separator (`/`).
-            if part.is_empty() || *part == "." || *part == ".." || part.contains('/') {
+            // produce `//` (empty), or smuggle an extra separator (`/`, `\`).
+            // The check runs on the *percent-decoded* segment because the raw
+            // segment is later passed through Url::parse, which decodes and
+            // normalises — so `%2E%2E` would otherwise survive the literal
+            // `..` check here and then collapse into a parent-dir reference.
+            let decoded = percent_encoding::percent_decode_str(part).decode_utf8_lossy();
+            if decoded.is_empty()
+                || decoded == "."
+                || decoded == ".."
+                || decoded.contains(['/', '\\'])
+            {
                 return Err(DIDWebVHError::InvalidMethodIdentifier(format!(
                     "Invalid URL: path segment ({part:?}) is not allowed",
                 )));
@@ -622,6 +631,27 @@ mod tests {
         assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:..:admin").is_err());
         assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:a:..").is_err());
         assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:.").is_err());
+    }
+
+    /// Regression: the traversal check used to compare the *raw* segment
+    /// against `..` / `.` / `/`, so `%2E%2E` passed — and then Url::parse
+    /// decoded and normalised it (`/%2E%2E/x/` → `/x/`), defeating the
+    /// check entirely. The check now percent-decodes first.
+    #[test]
+    fn url_rejects_pct_encoded_path_traversal() {
+        for did in [
+            "did:webvh:scid:example.com:%2E%2E:admin",
+            "did:webvh:scid:example.com:%2e%2e:admin",
+            "did:webvh:scid:example.com:.%2E",
+            "did:webvh:scid:example.com:%2E",
+            "did:webvh:scid:example.com:a%2Fb",
+            "did:webvh:scid:example.com:a%5Cb",
+        ] {
+            assert!(
+                WebVHURL::parse_did_url(did).is_err(),
+                "{did} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -85,7 +85,7 @@ impl WebVHURL {
         // split query from the rest of the URL
         let (prefix, query) = match prefix.split_once('?') {
             Some((prefix, query)) => (prefix, Some(query.to_string())),
-            None => (url, None),
+            None => (prefix, None),
         };
 
         let (query_version_id, query_version_time, query_version_number) =
@@ -479,6 +479,20 @@ mod tests {
         };
 
         assert_eq!(parsed.fragment, Some("key-fragment".to_string()));
+        assert_eq!(parsed.domain, "example.com");
+    }
+
+    #[test]
+    fn url_with_fragment_no_query_does_not_leak_into_domain() {
+        // Regression: when a fragment was present but no query, the query-split
+        // fallback restored the original (fragment-bearing) string as the prefix,
+        // so the domain became `127.0.0.1#x` and dodged reject_ip_address().
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:127.0.0.1#x").is_err());
+
+        let parsed = WebVHURL::parse_did_url("did:webvh:scid:example.com:dir#frag").unwrap();
+        assert_eq!(parsed.domain, "example.com");
+        assert_eq!(parsed.path, "/dir/");
+        assert_eq!(parsed.fragment, Some("frag".to_string()));
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -123,6 +123,15 @@ impl WebVHURL {
         let mut path = String::new();
         let mut file_name = String::new();
         for part in parts[2..].iter() {
+            // These segments are joined with '/' into the HTTP path that the
+            // resolver fetches. Reject anything that would let a crafted DID
+            // escape its directory (`..`), collapse to the current dir (`.`),
+            // produce `//` (empty), or smuggle an extra separator (`/`).
+            if part.is_empty() || *part == "." || *part == ".." || part.contains('/') {
+                return Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                    "Invalid URL: path segment ({part:?}) is not allowed",
+                )));
+            }
             if part != &"whois" {
                 path.push('/');
                 path.push_str(part);
@@ -523,6 +532,19 @@ mod tests {
             "https://domain:8000/custom/path/whois.vp"
         );
         Ok(())
+    }
+
+    #[test]
+    fn url_rejects_path_traversal() {
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:..:admin").is_err());
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:a:..").is_err());
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:.").is_err());
+    }
+
+    #[test]
+    fn url_rejects_empty_or_slash_segment() {
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com::x").is_err());
+        assert!(WebVHURL::parse_did_url("did:webvh:scid:example.com:a/b").is_err());
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -250,6 +250,30 @@ impl WebVHURL {
         })
     }
 
+    /// Re-check the host *after* `Url::parse` has normalised it.
+    ///
+    /// `reject_ip_address()` runs on the raw DID segment, which has not been
+    /// percent-decoded — so `127%2E0%2E0%2E1` does not parse as an `IpAddr`
+    /// and slips through. `Url::parse` then decodes it to `127.0.0.1` and
+    /// the resolver would happily fetch from localhost (or
+    /// `169.254.169.254`, etc.). This check looks at what the HTTP client
+    /// will actually connect to, after all of the `url` crate's host
+    /// normalisation, and rejects any IP literal.
+    fn reject_ip_host(url: &Url) -> Result<(), DIDWebVHError> {
+        match url.host() {
+            Some(url::Host::Ipv4(ip)) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                "Invalid URL: IP addresses are not allowed, use a domain name instead: {ip}",
+            ))),
+            Some(url::Host::Ipv6(ip)) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                "Invalid URL: IP addresses are not allowed, use a domain name instead: {ip}",
+            ))),
+            Some(url::Host::Domain(_)) => Ok(()),
+            None => Err(DIDWebVHError::InvalidMethodIdentifier(
+                "Invalid URL: Must contain domain".to_string(),
+            )),
+        }
+    }
+
     /// Rejects IP addresses (both IPv4 and IPv6) as the domain component.
     /// The did:webvh spec requires domain names, not IP addresses.
     fn reject_ip_address(domain: &str) -> Result<(), DIDWebVHError> {
@@ -361,12 +385,11 @@ impl WebVHURL {
             url_string.push_str(&format!("#{fragment}",));
         }
 
-        match Url::parse(&url_string) {
-            Ok(url) => Ok(url),
-            Err(err) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
-                "Invalid URL: {err}",
-            ))),
-        }
+        let url = Url::parse(&url_string).map_err(|err| {
+            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
+        })?;
+        Self::reject_ip_host(&url)?;
+        Ok(url)
     }
 
     /// Returns the URL for a whois.vp file location
@@ -382,12 +405,11 @@ impl WebVHURL {
             url_string.push_str("whois.vp");
         }
 
-        match Url::parse(&url_string) {
-            Ok(url) => Ok(url),
-            Err(err) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
-                "Invalid URL: {err}",
-            ))),
-        }
+        let url = Url::parse(&url_string).map_err(|err| {
+            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
+        })?;
+        Self::reject_ip_host(&url)?;
+        Ok(url)
     }
 
     /// Returns the URL for the #files service URL
@@ -402,12 +424,11 @@ impl WebVHURL {
             url_string.push_str(&self.path);
         }
 
-        match Url::parse(&url_string) {
-            Ok(url) => Ok(url),
-            Err(err) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
-                "Invalid URL: {err}",
-            ))),
-        }
+        let url = Url::parse(&url_string).map_err(|err| {
+            DIDWebVHError::InvalidMethodIdentifier(format!("Invalid URL: {err}"))
+        })?;
+        Self::reject_ip_host(&url)?;
+        Ok(url)
     }
 }
 
@@ -539,6 +560,33 @@ mod tests {
         // Previously slipped past reject_ip_address() because the unparsed
         // `%3a8080` suffix stayed glued to the host.
         assert!(WebVHURL::parse_did_url("did:webvh:scid:127.0.0.1%3a8080").is_err());
+    }
+
+    /// Regression: `reject_ip_address()` runs on the raw, still-percent-
+    /// encoded domain segment, so `127%2E0%2E0%2E1` is not an `IpAddr` and
+    /// passes — but `Url::parse` then decodes it to `127.0.0.1` and the
+    /// resolver would fetch from localhost. `get_http_url` now re-checks
+    /// the host *after* parse so the encoding the attacker chooses no
+    /// longer matters.
+    #[test]
+    fn url_rejects_pct_encoded_ip_host() {
+        for did in [
+            "did:webvh:scid:127%2E0%2E0%2E1",
+            "did:webvh:scid:127%2e0%2e0%2e1",
+            "did:webvh:scid:169%2E254%2E169%2E254",
+            "did:webvh:scid:127%2E0%2E0%2E1%3A8080",
+        ] {
+            let parsed = WebVHURL::parse_did_url(did).expect("parse stage doesn't decode");
+            let err = parsed
+                .get_http_url(None)
+                .expect_err("post-parse host check must reject the decoded IP");
+            assert!(
+                err.to_string().contains("IP addresses are not allowed"),
+                "{did} -> {err}"
+            );
+            assert!(parsed.get_http_whois_url().is_err());
+            assert!(parsed.get_http_files_url().is_err());
+        }
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -563,10 +563,7 @@ mod tests {
         };
         // No `{SCID}` placeholder — the doc id keeps this fake SCID while
         // parameters.scid is set to the real genesis hash.
-        let doc = did_doc_with_key(
-            "did:webvh:QmFakeScidNotTheRealHash:localhost%3A8000",
-            &key,
-        );
+        let doc = did_doc_with_key("did:webvh:QmFakeScidNotTheRealHash:localhost%3A8000", &key);
 
         let mut state = DIDWebVHState::default();
         state
@@ -773,9 +770,9 @@ mod tests {
             entry.validation_status = LogEntryValidationStatus::NotValidated;
         }
 
-        let err = state.validate().expect_err(
-            "cross-DID witness proof must not satisfy this log's threshold",
-        );
+        let err = state
+            .validate()
+            .expect_err("cross-DID witness proof must not satisfy this log's threshold");
         assert!(
             err.to_string().contains("threshold"),
             "expected threshold failure, got: {err}"

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -539,6 +539,53 @@ mod tests {
         assert!(err.to_string().contains("past the deactivation entry"));
     }
 
+    /// Regression: `verify_scid()` proved `parameters.scid` was the genesis
+    /// self-hash but never checked that the SCID embedded in the DID
+    /// document's `id` was that same value. An attacker could publish a
+    /// genesis with `state.id = "did:webvh:<anything>:host"` and
+    /// `parameters.scid = <real-hash>` — `verify_scid` passed, and a
+    /// resolver requesting `did:webvh:<anything>:host` would match it
+    /// against `state["id"]` and accept. The SCID in the DID the user typed
+    /// then has zero cryptographic binding to the log.
+    ///
+    /// `create_log_entry` builds exactly this when the supplied document's
+    /// `id` uses a literal string instead of the `{SCID}` placeholder: the
+    /// `{SCID}` → real-hash substitution only touches `parameters.scid`.
+    #[tokio::test]
+    async fn test_validate_rejects_scid_mismatch_between_params_and_doc_id() {
+        let key = generate_signing_key();
+        let params = Parameters {
+            update_keys: Some(Arc::new(vec![Multibase::new(
+                key.get_public_keymultibase().unwrap(),
+            )])),
+            portable: Some(false),
+            ..Default::default()
+        };
+        // No `{SCID}` placeholder — the doc id keeps this fake SCID while
+        // parameters.scid is set to the real genesis hash.
+        let doc = did_doc_with_key(
+            "did:webvh:QmFakeScidNotTheRealHash:localhost%3A8000",
+            &key,
+        );
+
+        let mut state = DIDWebVHState::default();
+        state
+            .create_log_entry(None, &doc, &params, &key)
+            .await
+            .unwrap();
+        for entry in &mut state.log_entries {
+            entry.validation_status = LogEntryValidationStatus::NotValidated;
+        }
+
+        let err = state
+            .validate()
+            .expect_err("doc-id SCID must match the verified parameters.scid");
+        assert!(
+            err.to_string().contains("does not match parameters.scid"),
+            "got: {err}"
+        );
+    }
+
     /// Tests that an invalid first log entry produces an immediate error.
     ///
     /// If the very first entry in the log is malformed (e.g., missing a proof),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -274,6 +274,22 @@ impl DIDWebVHState {
         self.witness_proofs
             .generate_proof_state(highest_version_number)?;
 
+        // Bind witness proofs to *this* log: a witness signs `{"versionId": X}`,
+        // and that signature is only meaningful here if X is the versionId of an
+        // entry in this log. The witness-proofs file is fetched from the
+        // (potentially compromised) DID host, so without this check an attacker
+        // can replay a genuine proof that W issued for a *different* DID's entry
+        // "N-otherhash" — the later-proof branch in validate_log_entry would
+        // verify the signature against the claimed versionId and count it.
+        let valid_version_ids: std::collections::HashSet<&str> = self
+            .log_entries
+            .iter()
+            .map(|e| e.get_version_id())
+            .collect();
+        self.witness_proofs
+            .witness_version
+            .retain(|_, (version_id, _, _)| valid_version_ids.contains(version_id.as_str()));
+
         // Step 4: Validate the witness proofs
         for log_entry in self.log_entries.iter_mut() {
             debug!("Witness Proof Validating: {}", log_entry.get_version_id());
@@ -595,6 +611,128 @@ mod tests {
     #[tokio::test]
     async fn test_validate_ttl_custom() {
         assert_ttl_produces_expiry(Some(7200), 7200).await;
+    }
+
+    /// Regression test for cross-DID witness-proof replay.
+    ///
+    /// A witness signs `{"versionId": X}`. That signature is *globally* valid
+    /// — it does not name the DID. So if witness W also witnesses some other
+    /// DID, an attacker who controls this DID's host can lift W's genuine
+    /// proof for `"3-<other-hash>"` from the other DID's witness file and drop
+    /// it into this one. Before the fix, the later-version branch in
+    /// `validate_log_entry` would verify the signature against the *claimed*
+    /// versionId (which checks out — W really signed it) and count it toward
+    /// the threshold for entries 1 and 2, even though `"3-<other-hash>"` is
+    /// not an entry in this log at all.
+    ///
+    /// Scenario built here:
+    ///   - entry 1: sets `witness: {threshold:1, [W]}` → entry 1 needs W
+    ///   - entry 2: sets `witness: {}` (off) → entry 2 still needs W (active
+    ///     witness is the *previous* entry's config)
+    ///   - entry 3: no witness param → active_witness is None, no proof needed
+    ///   - witness file: one genuine W signature over `"3-crossdidhash"`,
+    ///     replayed from a different DID
+    ///
+    /// Without the fix: entries 1 and 2 are satisfied via the later-version
+    /// branch, entry 3 needs nothing → full validation passes with W never
+    /// having signed anything in this log. With the fix: the replayed proof's
+    /// versionId is not in this log, so it is dropped before witness
+    /// validation and entry 1 fails its threshold.
+    #[tokio::test]
+    async fn test_validate_rejects_cross_did_witness_replay() {
+        use crate::witness::{Witness, Witnesses};
+        use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+
+        let base_time = (Utc::now() - Duration::seconds(1000)).fixed_offset();
+        let controller = generate_signing_key();
+        let controller_mb = Multibase::new(controller.get_public_keymultibase().unwrap());
+
+        // Witness key — secret.id must be the did:key VM so the proof's
+        // verificationMethod matches what validate_log_entry looks up.
+        let witness_secret =
+            affinidi_secrets_resolver::secrets::Secret::generate_ed25519(None, None);
+        let w_pk = witness_secret.get_public_keymultibase().unwrap();
+        let mut witness_secret = witness_secret.clone();
+        witness_secret.id = format!("did:key:{w_pk}#{w_pk}");
+
+        let doc = did_doc_with_key("did:webvh:{SCID}:localhost%3A8000", &controller);
+        let mut state = DIDWebVHState::default();
+
+        // Entry 1: turn on witnessing.
+        state
+            .create_log_entry(
+                Some(base_time),
+                &doc,
+                &Parameters {
+                    update_keys: Some(Arc::new(vec![controller_mb.clone()])),
+                    portable: Some(false),
+                    witness: Some(Arc::new(Witnesses::Value {
+                        threshold: 1,
+                        witnesses: vec![Witness {
+                            id: Multibase::new(format!("did:key:{w_pk}")),
+                        }],
+                    })),
+                    ..Default::default()
+                },
+                &controller,
+            )
+            .await
+            .unwrap();
+        let actual_doc = state.log_entries.last().unwrap().get_state().clone();
+
+        // Entry 2: turn witnessing off (takes effect at entry 3).
+        state
+            .create_log_entry(
+                Some(base_time + Duration::seconds(1)),
+                &actual_doc,
+                &Parameters {
+                    witness: Some(Arc::new(Witnesses::Empty {})),
+                    ..Default::default()
+                },
+                &controller,
+            )
+            .await
+            .unwrap();
+
+        // Entry 3: no witness needed.
+        state
+            .create_log_entry(
+                Some(base_time + Duration::seconds(2)),
+                &actual_doc,
+                &Parameters::default(),
+                &controller,
+            )
+            .await
+            .unwrap();
+
+        // The replayed proof: W's genuine signature over a versionId from a
+        // *different* DID's log. Version number 3 ≤ highest (3) so it survives
+        // generate_proof_state, and 3 > {1,2} so entries 1 and 2 hit the
+        // later-version branch — which only checks the signature against the
+        // claimed versionId, not against this log.
+        let replayed = DataIntegrityProof::sign(
+            &json!({"versionId": "3-crossdidhash"}),
+            &witness_secret,
+            SignOptions::new(),
+        )
+        .await
+        .unwrap();
+        state
+            .witness_proofs
+            .add_proof("3-crossdidhash", &replayed, false)
+            .unwrap();
+
+        for entry in &mut state.log_entries {
+            entry.validation_status = LogEntryValidationStatus::NotValidated;
+        }
+
+        let err = state.validate().expect_err(
+            "cross-DID witness proof must not satisfy this log's threshold",
+        );
+        assert!(
+            err.to_string().contains("threshold"),
+            "expected threshold failure, got: {err}"
+        );
     }
 
     /// Tests that validating a state with no log entries at all returns an error.

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -130,6 +130,20 @@ impl Witnesses {
                         threshold
                     )));
                 }
+                // Reject duplicate witness IDs. validate_log_entry() iterates the
+                // configured witness list and counts one match per entry, so a list
+                // like [W1, W1, W1] with threshold 3 would let a single proof from
+                // W1 satisfy the threshold — defeating the whole point of requiring
+                // multiple independent witnesses.
+                let mut seen = std::collections::HashSet::with_capacity(witnesses.len());
+                for w in witnesses {
+                    if !seen.insert(w.id.as_str()) {
+                        return Err(DIDWebVHError::ValidationError(format!(
+                            "Witness ({}) appears more than once in the witness list",
+                            w.id
+                        )));
+                    }
+                }
             }
             _ => {
                 return Err(DIDWebVHError::ValidationError(
@@ -286,6 +300,26 @@ mod tests {
         };
         let err = w.validate().unwrap_err();
         assert!(err.to_string().contains("less than the threshold"));
+    }
+
+    /// Tests that a witness list containing the same witness ID more than once is
+    /// rejected. Duplicates would otherwise let a single witness's proof be counted
+    /// multiple times toward the threshold during validation.
+    #[test]
+    fn test_validate_duplicate_witnesses_error() {
+        let w = Witnesses::Value {
+            threshold: 2,
+            witnesses: vec![
+                Witness {
+                    id: Multibase::new("w1"),
+                },
+                Witness {
+                    id: Multibase::new("w1"),
+                },
+            ],
+        };
+        let err = w.validate().unwrap_err();
+        assert!(err.to_string().contains("more than once"));
     }
 
     /// Tests that a valid witness configuration passes validation successfully.

--- a/src/witness/validate.rs
+++ b/src/witness/validate.rs
@@ -21,9 +21,12 @@
 
 use crate::{
     DIDWebVHError,
+    log_entry::{PublicKey, enforce_witness_proof_shape},
     log_entry_state::LogEntryState,
     witness::{WitnessVerifyOptions, proofs::WitnessProofCollection},
 };
+use affinidi_data_integrity::VerifyOptions;
+use serde_json::json;
 use tracing::{debug, warn};
 
 impl WitnessProofCollection {
@@ -58,7 +61,8 @@ impl WitnessProofCollection {
         let mut valid_proofs = 0;
         for w in witness_nodes {
             let did_key_vm = w.as_did_key();
-            let Some((_, oldest_id, proof)) = self.witness_version.get(&did_key_vm) else {
+            let Some((proof_version_id, oldest_id, proof)) = self.witness_version.get(&did_key_vm)
+            else {
                 // No proof available for this witness, threshold will catch if too few proofs
                 debug!("No Witness proofs exist for witness ({})", w.id);
                 continue;
@@ -84,13 +88,32 @@ impl WitnessProofCollection {
                 oldest_id, version_number
             );
             if oldest_id > &version_number {
-                // This proof is older than the current LogEntry, skip it
+                // This proof is for a *later* published LogEntry. It transitively
+                // attests this earlier entry, but we cannot assume it will be
+                // verified later: if the witness was rotated out before that
+                // version, no entry will ever check it. Verify the signature
+                // here against the versionId the proof actually covers before
+                // counting it toward the threshold.
+                enforce_witness_proof_shape(proof, options)?;
+                proof
+                    .verify_with_public_key(
+                        &json!({"versionId": &**proof_version_id}),
+                        proof.get_public_key_bytes()?.as_slice(),
+                        VerifyOptions::new(),
+                    )
+                    .map_err(|e| {
+                        DIDWebVHError::WitnessProofError(format!(
+                            "LogEntry ({}): Witness proof for later version ({}) failed verification: {}",
+                            log_entry.get_version_id(),
+                            proof_version_id,
+                            e
+                        ))
+                    })?;
                 debug!(
-                    "LogEntry ({}): Skipping witness proof from {} (oldest: {oldest_id})",
+                    "LogEntry ({}): later witness proof from {} (for {oldest_id}) verified ok",
                     log_entry.get_version_id(),
                     w.id,
                 );
-                // Still counts as a valid proof
                 valid_proofs += 1;
                 continue;
             } else {
@@ -320,16 +343,55 @@ mod tests {
     /// A proof attesting to a later (but still published) version should still satisfy
     /// the witness requirement for earlier entries, supporting efficient batched
     /// witnessing.
+    #[tokio::test]
+    async fn test_witness_proof_older_than_current_counts() {
+        let mut proofs = WitnessProofCollection::default();
+        let secret = affinidi_secrets_resolver::secrets::Secret::generate_ed25519(None, None);
+        let pk = secret.get_public_keymultibase().unwrap();
+        let mut witness_secret = secret.clone();
+        witness_secret.id = format!("did:key:{pk}#{pk}");
+
+        // A genuine signature over version 3 — must verify when counted toward version 1.
+        let signed_proof = DataIntegrityProof::sign(
+            &json!({"versionId": "3-hash"}),
+            &witness_secret,
+            SignOptions::new(),
+        )
+        .await
+        .unwrap();
+        proofs.add_proof("3-hash", &signed_proof, false).unwrap();
+
+        let witnesses = Witnesses::Value {
+            threshold: 1,
+            witnesses: vec![Witness {
+                id: Multibase::new(format!("did:key:{pk}")),
+            }],
+        };
+        let entry = make_witnessed_entry("1-abcd", witnesses);
+        // highest_version_number=5, proof is for version 3
+        // oldest_id(3) <= highest(5) but oldest_id(3) > version_number(1) → verified, then counted
+        proofs
+            .validate_log_entry(&entry, 5, &WitnessVerifyOptions::new())
+            .expect("Older proof should still count as valid");
+    }
+
+    /// Tests that a *forged* witness proof for a later-but-published version is
+    /// rejected and does not count toward the threshold.
+    ///
+    /// This is the security regression test for the threshold bypass: previously,
+    /// a proof for version N > current was counted without signature verification,
+    /// on the assumption it would be checked when version N was processed. But if
+    /// the witness had been rotated out before version N, the forged proof was
+    /// never verified anywhere.
     #[test]
-    fn test_witness_proof_older_than_current_counts() {
+    fn test_witness_proof_later_version_forged_rejected() {
         use crate::test_utils::make_test_proof;
         let mut proofs = WitnessProofCollection::default();
         let raw_key = "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6";
         let witness_id = format!("did:key:{raw_key}");
         let vm = format!("{witness_id}#{raw_key}");
+        // Unsigned/garbage proof claiming to attest version 3.
         let proof = make_test_proof(&vm);
-        // Add proof for version 3 — version_number is 1, oldest_id (3) > version_number (1)
-        // But oldest_id (3) <= highest_version_number (5) → still counts as valid
         proofs.add_proof("3-hash", &proof, false).unwrap();
 
         let witnesses = Witnesses::Value {
@@ -339,11 +401,11 @@ mod tests {
             }],
         };
         let entry = make_witnessed_entry("1-abcd", witnesses);
-        // highest_version_number=5, proof is for version 3
-        // oldest_id(3) <= highest(5) but oldest_id(3) > version_number(1) → counts as valid
-        proofs
+        // highest=5, proof claims version 3 (>1, ≤5): must be verified, and verification must fail.
+        let err = proofs
             .validate_log_entry(&entry, 5, &WitnessVerifyOptions::new())
-            .expect("Older proof should still count as valid");
+            .expect_err("forged later-version proof must not satisfy threshold");
+        assert!(err.to_string().contains("Witness"));
     }
 
     /// Tests the happy path where a valid, cryptographically signed witness proof

--- a/src/witness/validate.rs
+++ b/src/witness/validate.rs
@@ -3,19 +3,34 @@
 *
 *   # Witness proof version semantics
 *
-*   A witness proof attests that a witness observed a particular version of the DID log.
-*   During validation, proofs are matched against log entries with the following rules:
+*   A witness proof attests that a witness observed a particular version of
+*   the DID log. The spec rule (§ "Verifying Witness Proofs During
+*   Resolution") is "current or any later" — a proof at version K covers
+*   entries ≤ K. During validation, proofs are matched against log entries
+*   with the following rules, applied per witness against the witness's
+*   highest-versioned stored proof:
 *
-*   - **Future proofs** (proof version > highest published version) are **skipped** entirely,
-*     preventing premature acceptance of proofs for unpublished entries.
-*   - **Older proofs** (proof version > current entry version, but within published range)
-*     **still count** toward the threshold. This supports efficient batched witnessing
-*     where a single proof covers a range of entries.
-*   - **Current proofs** (proof version == current entry version) are **cryptographically
-*     verified** against the log entry data before counting.
+*   - **Future proofs** (proof version > highest published version) are
+*     **skipped** entirely, preventing premature acceptance of proofs for
+*     unpublished entries.
+*   - **Later-but-published proofs** (proof version > current entry version,
+*     ≤ highest published) are **cryptographically verified against the
+*     proof's own versionId** before counting. They cover the current entry
+*     transitively per spec.
+*   - **Current proofs** (proof version == current entry version) are
+*     **cryptographically verified** against the current entry's data before
+*     counting.
+*   - **Older proofs** (proof version < current entry version) **do NOT
+*     count** toward this entry's threshold (spec § "current or any later").
+*     They are silently skipped at debug level — if too few witnesses have
+*     a current-or-later proof, the threshold check surfaces as
+*     "threshold not met", which is the correct semantic error rather than
+*     a misleading "signature invalid" from trying to verify a proof against
+*     the wrong payload.
 *
-*   This design means a resolver cannot be tricked by proofs referencing unpublished
-*   future entries, while still allowing witnesses to attest in batches rather than
+*   This design means a resolver cannot be tricked by proofs referencing
+*   unpublished future entries, while still allowing witnesses to attest in
+*   batches (one proof covering multiple older entries) rather than
 *   per-entry.
 */
 
@@ -83,80 +98,83 @@ impl WitnessProofCollection {
                 continue;
             }
 
-            debug!(
-                "oldest_id ({}) >  version_number ({})",
-                oldest_id, version_number
-            );
-            if oldest_id > &version_number {
-                // This proof is for a *later* published LogEntry. It transitively
-                // attests this earlier entry, but we cannot assume it will be
-                // verified later: if the witness was rotated out before that
-                // version, no entry will ever check it. Verify the signature
-                // here against the versionId the proof actually covers before
-                // counting it toward the threshold.
-                enforce_witness_proof_shape(proof, options)?;
-                proof
-                    .verify_with_public_key(
-                        &json!({"versionId": &**proof_version_id}),
-                        proof.get_public_key_bytes()?.as_slice(),
-                        VerifyOptions::new(),
-                    )
-                    .map_err(|e| {
-                        DIDWebVHError::WitnessProofError(format!(
-                            "LogEntry ({}): Witness proof for later version ({}) failed verification: {}",
-                            log_entry.get_version_id(),
-                            proof_version_id,
-                            e
-                        ))
-                    })?;
-                debug!(
-                    "LogEntry ({}): later witness proof from {} (for {oldest_id}) verified ok",
-                    log_entry.get_version_id(),
-                    w.id,
-                );
-                valid_proofs += 1;
-                continue;
-            } else if oldest_id == &version_number {
-                // witness proof is for this version of the LogEntry —
-                // verify against this entry's versionId.
-                log_entry
-                    .log_entry
-                    .validate_witness_proof(proof, options)
-                    .map_err(|e| {
-                        DIDWebVHError::WitnessProofError(format!(
-                            "LogEntry ({}): Witness proof validation failed: {}",
-                            log_entry.get_version_id(),
-                            e
-                        ))
-                    })?;
-                valid_proofs += 1;
-                debug!(
-                    "LogEntry ({}): Witness proof ({}) verified ok",
-                    log_entry.get_version_id(),
-                    w.id
-                );
-            } else {
-                // oldest_id < version_number. The stored proof is for an
-                // *earlier* published entry than the one we are validating.
-                // Per didwebvh 1.0 § "Verifying Witness Proofs During
-                // Resolution", a proof at version K only counts for entries
-                // ≤ K (the "current or any later" rule, equivalently "a
-                // valid proof carries the implication that all prior log
-                // entries are also approved"). So this proof does NOT
-                // approve the current entry and MUST NOT be counted toward
-                // the threshold. We silently skip it; if too few witnesses
-                // have a current-or-later proof the threshold check at the
-                // bottom of this function will surface as "threshold not
-                // met", which is the correct semantic error (rather than
-                // attempting to verify the proof against the current
-                // versionId and surfacing a misleading "signature invalid"
-                // failure when the bytes simply don't match).
-                debug!(
-                    "LogEntry ({}): older witness proof from {} (for {oldest_id}) does not approve current entry per spec; not counted toward threshold",
-                    log_entry.get_version_id(),
-                    w.id,
-                );
-                continue;
+            debug!("oldest_id ({oldest_id}) vs. version_number ({version_number})",);
+            match oldest_id.cmp(&version_number) {
+                std::cmp::Ordering::Greater => {
+                    // This proof is for a *later* published LogEntry. It
+                    // transitively attests this earlier entry, but we cannot
+                    // assume it will be verified later: if the witness was
+                    // rotated out before that version, no entry will ever
+                    // check it. Verify the signature here against the
+                    // versionId the proof actually covers before counting
+                    // it toward the threshold.
+                    enforce_witness_proof_shape(proof, options)?;
+                    proof
+                        .verify_with_public_key(
+                            &json!({ "versionId": &**proof_version_id }),
+                            proof.get_public_key_bytes()?.as_slice(),
+                            VerifyOptions::new(),
+                        )
+                        .map_err(|e| {
+                            DIDWebVHError::WitnessProofError(format!(
+                                "LogEntry ({}): Witness proof for later version ({}) failed verification: {}",
+                                log_entry.get_version_id(),
+                                proof_version_id,
+                                e
+                            ))
+                        })?;
+                    debug!(
+                        "LogEntry ({}): later witness proof from {} (for {oldest_id}) verified ok",
+                        log_entry.get_version_id(),
+                        w.id,
+                    );
+                    valid_proofs += 1;
+                    continue;
+                }
+                std::cmp::Ordering::Equal => {
+                    // witness proof is for this version of the LogEntry —
+                    // verify against this entry's versionId.
+                    log_entry
+                        .log_entry
+                        .validate_witness_proof(proof, options)
+                        .map_err(|e| {
+                            DIDWebVHError::WitnessProofError(format!(
+                                "LogEntry ({}): Witness proof validation failed: {}",
+                                log_entry.get_version_id(),
+                                e
+                            ))
+                        })?;
+                    valid_proofs += 1;
+                    debug!(
+                        "LogEntry ({}): Witness proof ({}) verified ok",
+                        log_entry.get_version_id(),
+                        w.id
+                    );
+                }
+                std::cmp::Ordering::Less => {
+                    // The stored proof is for an *earlier* published entry
+                    // than the one we are validating. Per didwebvh 1.0
+                    // § "Verifying Witness Proofs During Resolution", a
+                    // proof at version K only counts for entries ≤ K (the
+                    // "current or any later" rule — equivalently, a valid
+                    // proof carries the implication that all prior log
+                    // entries are also approved). So this proof does NOT
+                    // approve the current entry and MUST NOT be counted
+                    // toward the threshold. We silently skip it; if too
+                    // few witnesses have a current-or-later proof the
+                    // threshold check at the bottom of this function will
+                    // surface as "threshold not met", which is the correct
+                    // semantic error (rather than attempting to verify the
+                    // proof against the current versionId and surfacing a
+                    // misleading "signature invalid" failure when the
+                    // bytes simply don't match).
+                    debug!(
+                        "LogEntry ({}): older witness proof from {} (for {oldest_id}) does not approve current entry per spec; not counted toward threshold",
+                        log_entry.get_version_id(),
+                        w.id,
+                    );
+                    continue;
+                }
             }
         }
 

--- a/src/witness/validate.rs
+++ b/src/witness/validate.rs
@@ -116,9 +116,9 @@ impl WitnessProofCollection {
                 );
                 valid_proofs += 1;
                 continue;
-            } else {
-                // witness proof is for this verion of the LogEntry
-                // Validate the LogEntry against the proof
+            } else if oldest_id == &version_number {
+                // witness proof is for this version of the LogEntry —
+                // verify against this entry's versionId.
                 log_entry
                     .log_entry
                     .validate_witness_proof(proof, options)
@@ -135,6 +135,28 @@ impl WitnessProofCollection {
                     log_entry.get_version_id(),
                     w.id
                 );
+            } else {
+                // oldest_id < version_number. The stored proof is for an
+                // *earlier* published entry than the one we are validating.
+                // Per didwebvh 1.0 § "Verifying Witness Proofs During
+                // Resolution", a proof at version K only counts for entries
+                // ≤ K (the "current or any later" rule, equivalently "a
+                // valid proof carries the implication that all prior log
+                // entries are also approved"). So this proof does NOT
+                // approve the current entry and MUST NOT be counted toward
+                // the threshold. We silently skip it; if too few witnesses
+                // have a current-or-later proof the threshold check at the
+                // bottom of this function will surface as "threshold not
+                // met", which is the correct semantic error (rather than
+                // attempting to verify the proof against the current
+                // versionId and surfacing a misleading "signature invalid"
+                // failure when the bytes simply don't match).
+                debug!(
+                    "LogEntry ({}): older witness proof from {} (for {oldest_id}) does not approve current entry per spec; not counted toward threshold",
+                    log_entry.get_version_id(),
+                    w.id,
+                );
+                continue;
             }
         }
 


### PR DESCRIPTION
# Security patch series + v0.5.3 release

Closes #39 (see comment thread for full review of each test-suite finding).

Bumps the crate to `0.5.3` and applies a 15-commit security-fix series
together with one error-message clarity fix surfaced while reviewing
the test-suite cross-resolution results.

## What's in this PR

### Dependency refresh (1 commit)

`chore: update deps and bump version to 0.5.3` — patch-level dep
refresh + version bump. No major-version churn, no Cargo.toml
constraints widened beyond `serde_with` 3.18 → 3.20 to reflect the
actual minimum.

### Security fixes (15 commits)

Each commit preserves its original author and carries my DCO
sign-off. Every fix is accompanied by a regression test in the same
commit. The series addresses 15 distinct vulnerabilities found by a
cross-implementation audit of `didwebvh-rs`, `didwebvh-py`,
`didwebvh-ts`, and `didwebvh-java`.

| # | Commit subject | Severity | What it closes |
|---|---|:---:|---|
| 1 | `fix: reject mismatched did:key body/fragment in log-entry proof authorization` | **C** | Full forgery — authorisation check used the fragment, signature verification used the body |
| 2 | `fix: disable HTTP redirects in DID resolution to prevent SSRF` | H | Resolver followed 30x to internal IPs, bypassing the IP-rejection check |
| 3 | `fix: reject duplicate witness IDs to prevent threshold bypass` | H | Controller could weaken own witness threshold by listing the same witness multiple times |
| 4 | `fix: reject path-traversal segments when converting DID to HTTP URL` | M | `did:webvh:<scid>:host:..:..:admin` reached arbitrary host paths |
| 5 | `fix: match lowercase %3a when splitting host:port in DID URL parsing` | H | Lowercase percent-encoding bypassed the IP-literal rejection |
| 6 | `fix: don't re-include stripped fragment when DID URL has no query` | H | Swapped-variable bug: `127.0.0.1#x` reached the host check as `127.0.0.1#x` (not parseable as IP) |
| 7 | `witness: verify "later version" proofs before counting toward threshold` | **C** | Forged later-version witness proof was counted without signature verification |
| 8 | `did_web: don't panic on malformed id in convert_webvh_id_to_web_id` | L | Out-of-bounds slice on attacker-controlled `state.id` caused panic |
| 9 | `parameters: require updateKeys when previous entry committed nextKeyHashes` | **C** | Pre-rotation bypass via omitted `updateKeys` — re-used old (possibly compromised) key |
| 10 | `log_entry: enforce eddsa-jcs-2022 cryptosuite on controller proofs` | M | Spec mandates suite; resolver only checked `proofPurpose` |
| 11 | `validate: bind witness proofs to this log's versionIds` | **C** | Cross-DID witness proof replay |
| 12 | `url: re-check host after Url::parse to block percent-encoded IP bypass` | H | `127%2E0%2E0%2E1` decoded to 127.0.0.1 after the IP check |
| 13 | `url: percent-decode path segments before the traversal check` | M | `%2E%2E` survived a literal `..` check then decoded |
| 14 | `log_entry: bind the DID document's SCID to the verified parameters.scid` | **C** | Genesis `state.id` SCID had no cryptographic binding to `parameters.scid` |
| 15 | `log_entry: enforce SCID immutability across every entry, not just genesis` | **C** | Portable entries could change SCID, reopening #14 at N > 1 |

### Post-patch cleanup (2 commits)

- `style: cargo fmt across patched files` — mechanical rustfmt
  cleanup of the three files touched by the series.
- `witness: distinguish older-version proofs from current-version proofs`
  — splits an `if/else` that was conflating "proof for current entry"
  with "proof for older entry", surfaced while reviewing issue #39.
  Per spec § "Verifying Witness Proofs During Resolution", an
  older-version proof does NOT approve a newer entry. Behaviour is
  unchanged (still rejects), but the error becomes accurate:
  **"Witness proof threshold (N) was not met. Only (M) proofs were
  validated"** instead of the misleading "signature invalid".

## Test status

```
$ cargo test --lib            # 429 passed
$ cargo test --tests          # 21 passed
$ cargo test --doc            # 2 passed
$ cargo build --all-features  # clean (except the pre-existing
                              # experimental-pqc / affinidi-crypto
                              # vs ml-dsa upstream incompatibility,
                              # which is unrelated to this branch)
```

Each security commit ships its own regression test in the same diff:

- `test_authorized_keys_mismatched_body_and_fragment_rejected` (#1)
- `test_validate_duplicate_witnesses_error` (#3)
- `url_rejects_path_traversal`, `url_rejects_empty_or_slash_segment` (#4)
- `url_with_lowercase_pct_port`, `url_rejects_ipv4_with_lowercase_pct_port` (#5)
- `url_with_fragment_no_query_does_not_leak_into_domain` (#6)
- `test_witness_proof_later_version_forged_rejected` (#7)
- `test_convert_webvh_to_web_malformed_no_panic` (#8)
- `validate_update_keys_absent_pre_rotation_active_error`, `validate_update_keys_empty_pre_rotation_active_error` (#9)
- `test_invalid_cryptosuite_rejected` (#10)
- `test_validate_rejects_cross_did_witness_replay` (#11)
- `url_rejects_pct_encoded_ip_host` (#12)
- `url_rejects_pct_encoded_path_traversal` (#13)
- `test_validate_rejects_scid_mismatch_between_params_and_doc_id` (#14)
- `test_portability_rejects_scid_change` (#15)

## Test-suite delta against PR #4 vectors

Running against
[`decentralized-identity/didwebvh-test-suite#4`](https://github.com/decentralized-identity/didwebvh-test-suite/pull/4)
vectors with the local `implementations/rust/` harness pointed at this
branch:

| Scenario | Log producer | Before this branch | After this branch |
|---|---|---|---|
| `basic-update` / `deactivate` / `key-rotation` / `multi-update` / `multiple-update-keys` / `pre-rotation-consume` / `services` | java-eecc | ❌ FAIL ("Log truncated…") | 🔶 DIFF (resolves; formatting variance only) |
| `basic-update` / `deactivate` / `key-rotation` / `multi-update` / `multiple-update-keys` / `portable-move` / `services` / `witness-update` | ts | ⚠️ XFAIL ("nextKeyHashes:[]") | 🔶 DIFF (library accepts; harness pre-check is now stale) |
| `witness-update` | java / java-eecc / python | ❌ FAIL ("signature invalid") | ❌ FAIL ("threshold not met" — spec-correct error; see #39 comment for why this is not a Rust bug) |

## Provenance of the security series

Authors as recorded in `git log` are preserved; each commit gets my
DCO sign-off. The 15-patch series was produced by an out-of-band
audit. All findings are reproducible from the regression tests in
each commit.

## Out of scope

- The `experimental-pqc` upstream compile error
  (`affinidi-crypto 0.1.5` vs newer `ml-dsa` API) is pre-existing
  and not introduced by this branch. Fix belongs upstream in
  `affinidi-crypto` or as a `ml-dsa` version pin (separate PR).
- The test-suite harness's `log_has_empty_next_key_hashes` XFAIL
  short-circuit can now be removed (the library accepts the shape).
  That's a test-suite PR, not a `didwebvh-rs` PR.
