### PR TITLE
fix: serialize witness IDs as did:key + dependency refresh (v0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # didwebvh-rs Changelog history
 
+## 7th June 2026
+
+### Release 0.5.4 — spec: witness IDs as `did:key` + dependency refresh
+
+Closes
+[#42](https://github.com/decentralized-identity/didwebvh-rs/issues/42).
+No public-API breakage. Pre-existing logs produced by spec-compliant
+implementations continue to resolve unchanged.
+
+#### Fixed
+
+- **Witness `id` is now serialized as a `did:key` identifier.** The
+  didwebvh 1.0 spec § "Witnesses" requires each entry in the `witnesses`
+  array to carry a `did:key` `id` (`did:key:z6Mk…`), but a `Witness`
+  built from a bare multibase key (`z6Mk…`) serialized the raw key,
+  producing non-spec, non-interoperable DID logs (the
+  `witness-threshold` / `witness-update` test-suite vectors showed
+  `"id":"z6Mk…"` instead of `"id":"did:key:z6Mk…"`). `Witness` now
+  canonicalizes its `id` to `did:key` form on both serialization and
+  deserialization, so output is spec-compliant regardless of how the
+  value was constructed. Canonicalization is a no-op for an
+  already-`did:key` id, so logs from spec-compliant implementations
+  round-trip byte-for-byte and their `entryHash` continues to verify.
+  Duplicate detection in `Witnesses::validate()` now compares on the
+  canonical form, and a new `Witness::new()` constructor applies the
+  same normalization.
+
+#### Changed
+
+- **`affinidi-data-integrity` 0.6 → 0.7.** Picked up via the
+  manifest bump; all other dependencies refreshed to their latest
+  semver-compatible versions (`cargo update`), pruning stale duplicate
+  trees (old `reqwest`, `hyper` 0.14, `rustls` 0.21, `bitflags` 1.x).
+
 ## 24th May 2026
 
 ### Release 0.5.3 — security: 15 patches from cross-implementation audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cac399b6d7547a9af38375e596dc6df60d206d02eec037e69f30600a37dac6"
+checksum = "2a56253d8878db88e02d70a0472ec7e346412a4dcf14b84a77cca096ecbbf4f0"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -43,6 +43,7 @@ dependencies = [
  "multibase 0.9.2",
  "p256",
  "p384",
+ "p521",
  "rand 0.10.1",
  "rand_core 0.6.4",
  "serde",
@@ -56,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce7f611e7bcad221aee953b8ef91d23e0f18ef319c711211357f03f14f63450"
+checksum = "be2413307935cc2126c9fc4890a0e38ed69329638b93590a936a2d5bd11a50d8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -79,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a10e1890c284e5d918492f55d58ed2fa442071ff88cfe52f2395e7ee3eb9b01"
+checksum = "4caccbd04e9f77b067659c9ac0312c4dfface553fe2375ceb7ed1affec550061"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -96,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-encoding"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0d6ba1e7fc9bde231c5c7d6e10f29b6822f93e20000dce2a4647d8de8c8d9a"
+checksum = "8b0faa57ab55df6fad876ac64a223532a9bb159b393d88b66887c1ae42c33f52"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -109,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-rdf-encoding"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c58001cb36e92473a758d4ab29882965347a2b9dd661db0a2761bc5cd2ffe8"
+checksum = "327366e7191a875eddcf0131e2b008e97fce1ba971e0442ac1835492316c0b2f"
 dependencies = [
  "serde",
  "serde_json",
@@ -122,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933214490477763c4c7eb01ec7438d58887b2994bbb8f5d4699b4c7a5acce52a"
+checksum = "a5df3f588537611ef80a97ddfaa9fef3d8070553fab051a44e974e66781eff64"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -374,12 +375,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -413,15 +408,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -629,9 +618,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -673,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -785,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1216,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1326,14 +1315,14 @@ dependencies = [
 
 [[package]]
 name = "did-ion"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b626e9dc778f2a8b0bc8f539c0baa6bc7857e148ce05f31617ef183cacaee5c"
+checksum = "2927c9aa8b64707fdcab002b3dfbb701d42519a310751c1bba2bebe2c14d4bac"
 dependencies = [
  "base64 0.22.1",
  "iref",
  "json-patch",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -1409,16 +1398,16 @@ dependencies = [
 
 [[package]]
 name = "did-tz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92df32726821890e7993fa9e7ce65888d3f703749d58f84b7cbe794c2e2a00cc"
+checksum = "727b42a800a1fe30bfeca8432fa964bd8db6f58e96d52b540d6becb267fb2521"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",
  "chrono",
  "iref",
  "json-patch",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "ssi-core",
@@ -1432,20 +1421,20 @@ dependencies = [
 
 [[package]]
 name = "did-web"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac0c0d2cc4d7e480dad858be3c9e1c3a6aa60789e1fe2ef434c732724b150cf"
+checksum = "0e6c3e262aabe7b1fb6373048f63b7e395221c83c8750bbb4a6784811a272673"
 dependencies = [
- "http 0.2.12",
+ "http",
  "iref",
- "reqwest 0.11.27",
+ "reqwest",
  "ssi-dids-core",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -1465,11 +1454,11 @@ dependencies = [
  "percent-encoding",
  "proptest",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "sha2 0.11.0",
  "ssi",
  "thiserror 2.0.18",
@@ -1515,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1964,25 +1953,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -1992,7 +1962,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2113,34 +2083,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -2150,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -2161,8 +2109,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2191,41 +2139,17 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2237,44 +2161,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -2285,7 +2182,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2303,15 +2200,15 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
- "system-configuration 0.7.0",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3053,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -3085,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -3113,9 +3010,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3124,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67011732d2747886c7b64f2eceef9d6eb2645a0aa528a26828b949ece257285"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
@@ -3350,7 +3247,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3438,6 +3335,20 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
 
@@ -3728,7 +3639,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3777,8 +3688,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.40",
- "socket2 0.6.3",
+ "rustls",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3798,7 +3709,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3816,7 +3727,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4006,7 +3917,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4075,105 +3986,21 @@ checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-tls 0.6.0",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2 0.4.14",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-tls 0.6.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -4182,13 +4009,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "sync_wrapper 1.0.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -4320,23 +4150,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -4348,30 +4166,21 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -4395,10 +4204,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4410,16 +4219,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4524,16 +4323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,7 +4348,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4725,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4739,7 +4528,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.20.0",
+ "serde_with_macros 3.21.0",
  "time",
 ]
 
@@ -4769,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4862,9 +4651,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -4974,19 +4763,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5354,15 +5133,15 @@ dependencies = [
 
 [[package]]
 name = "ssi-dids-core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3705a87c5241dc8f13dbebd0002376c78013eef1d41ad6291b5d91545a7b0569"
+checksum = "490c0fb68ff756edb02b61d0a2876299cbd9855b150c1f2c223fce9d5557f52b"
 dependencies = [
  "async-trait",
  "iref",
  "percent-encoding",
  "pin-project",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5579,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-status"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19111b7957c678fb5615fc0aa821fac59f8086ba24b8eb25f4c74fb475ec046"
+checksum = "4621b76031fcfcc739afbd0fbe4536f40c3c4bb310466f5428e74f5906e0a696"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -5590,7 +5369,7 @@ dependencies = [
  "multibase 0.9.2",
  "parking_lot",
  "rdf-types",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "ssi-claims-core",
@@ -5636,9 +5415,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-vc"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44929382388209e62b066cade4396f12806c911a3f1ffa1769ced73cebb2f374"
+checksum = "f3bb7825f7164be57b75eba4e0bc4e9870bd5ebfc8e900e08b3eb582ac653f6b"
 dependencies = [
  "base64 0.22.1",
  "bitvec 0.20.4",
@@ -5649,7 +5428,7 @@ dependencies = [
  "json-syntax",
  "linked-data",
  "rdf-types",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "ssi-claims-core",
@@ -5860,12 +5639,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5886,34 +5659,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5939,7 +5691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6079,7 +5831,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6107,21 +5859,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls",
  "tokio",
 ]
 
@@ -6149,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -6177,7 +5919,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6189,11 +5931,11 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -6308,9 +6050,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -6405,9 +6147,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6577,7 +6319,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6611,12 +6353,6 @@ checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -6721,15 +6457,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6753,21 +6480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6805,12 +6517,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6823,12 +6529,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6838,12 +6538,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6871,12 +6565,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6886,12 +6574,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6907,12 +6589,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6922,12 +6598,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6951,16 +6621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6970,9 +6630,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",
@@ -7047,7 +6707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -7133,9 +6793,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7156,18 +6816,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.3"
+version = "0.5.4"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"
@@ -43,7 +43,7 @@ experimental-pqc = [
 ]
 
 [dependencies]
-affinidi-data-integrity = { version = "0.6" }
+affinidi-data-integrity = { version = "0.7" }
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -859,8 +859,10 @@ mod tests {
             .authorization_key(key)
             .did_document(doc)
             .parameters(params)
-            .witness_secret(w1_id, witness1)
-            .witness_secret(w2_id, witness2)
+            // Witness ids are canonicalized to `did:key:` form (issue #42), so
+            // the witness-secret lookup map must be keyed the same way.
+            .witness_secret(format!("did:key:{w1_id}"), witness1)
+            .witness_secret(format!("did:key:{w2_id}"), witness2)
             .build()
             .unwrap();
 
@@ -1111,8 +1113,9 @@ mod tests {
         let log_entry = state.log_entries.last().unwrap();
 
         let mut secrets = HashMap::default();
-        secrets.insert(w1_id, witness1);
-        secrets.insert(w2_id, witness2);
+        // Witness ids are canonicalized to `did:key:` form (issue #42).
+        secrets.insert(format!("did:key:{w1_id}"), witness1);
+        secrets.insert(format!("did:key:{w2_id}"), witness2);
 
         let witnesses = log_entry.get_active_witnesses();
         let mut proofs = WitnessProofCollection::default();
@@ -1506,7 +1509,8 @@ mod tests {
         let log_entry_state = state.log_entries.last().unwrap();
 
         let mut secrets = HashMap::default();
-        secrets.insert(w1_id, witness1);
+        // Witness id is canonicalized to `did:key:` form (issue #42).
+        secrets.insert(format!("did:key:{w1_id}"), witness1);
 
         let witnesses = log_entry_state.get_active_witnesses();
         let mut proofs = WitnessProofCollection::default();
@@ -1546,7 +1550,8 @@ mod tests {
         let log_entry_state = state.log_entries.last().unwrap();
 
         let mut secrets = HashMap::default();
-        secrets.insert(w1_id, witness1);
+        // Witness id is canonicalized to `did:key:` form (issue #42).
+        secrets.insert(format!("did:key:{w1_id}"), witness1);
 
         let witnesses = log_entry_state.get_active_witnesses();
         let mut proofs = WitnessProofCollection::default();

--- a/src/parameters/spec_1_0.rs
+++ b/src/parameters/spec_1_0.rs
@@ -582,15 +582,13 @@ mod tests {
 
     #[test]
     fn witness_value_roundtrips() {
+        // Witness ids are canonicalized to `did:key:` form (issue #42), so use
+        // already-canonical ids to assert a lossless round-trip.
         let w = Witnesses::Value {
             threshold: 2,
             witnesses: vec![
-                Witness {
-                    id: Multibase::new("witness1"),
-                },
-                Witness {
-                    id: Multibase::new("witness2"),
-                },
+                Witness::new("z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6"),
+                Witness::new("z6MkqUa1LbqZ7EpevqrFC7XHAWM8CE49AKFWVjyu543NfVAp"),
             ],
         };
         let json = serde_json::to_string(&w).unwrap();
@@ -861,9 +859,11 @@ mod tests {
             "portable": true,
             "nextKeyHashes": ["zQmS6fKbreQixpa6JueaSuDiL2VQAGosC45TDQdKHf5E155"],
             "watchers": ["https://watcher.example.com"],
+            // Witness id must be `did:key:` per spec (issue #42); lossless
+            // round-trip holds only for the canonical form.
             "witness": {
                 "threshold": 1,
-                "witnesses": [{"id": "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6"}]
+                "witnesses": [{"id": "did:key:z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6"}]
             },
             "deactivated": false,
             "ttl": 7200
@@ -1029,11 +1029,13 @@ mod tests {
             "method": "did:webvh:1.0",
             "scid": "test",
             "updateKeys": ["key1"],
+            // Witness ids must be `did:key:` per spec (issue #42); the
+            // round-trip is lossless only for the canonical form.
             "witness": {
                 "threshold": 2,
                 "witnesses": [
-                    {"id": "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6"},
-                    {"id": "z6MkqUa1LbqZ7EpevqrFC7XHAWM8CE49AKFWVjyu543NfVAp"}
+                    {"id": "did:key:z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7lL8N8AC4Pp6"},
+                    {"id": "did:key:z6MkqUa1LbqZ7EpevqrFC7XHAWM8CE49AKFWVjyu543NfVAp"}
                 ]
             }
         }));

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -5,7 +5,9 @@
 use affinidi_data_integrity::crypto_suites::CryptoSuite;
 
 use crate::{DIDWebVHError, Multibase};
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer, de::Error as _, ser::SerializeStruct,
+};
 use std::fmt::Display;
 
 pub mod proofs;
@@ -137,7 +139,10 @@ impl Witnesses {
                 // multiple independent witnesses.
                 let mut seen = std::collections::HashSet::with_capacity(witnesses.len());
                 for w in witnesses {
-                    if !seen.insert(w.id.as_str()) {
+                    // Compare on the canonical `did:key:` form so that a bare
+                    // multibase key and its `did:key:`-prefixed equivalent are
+                    // recognized as the same witness (they serialize identically).
+                    if !seen.insert(w.as_did()) {
                         return Err(DIDWebVHError::ValidationError(format!(
                             "Witness ({}) appears more than once in the witness list",
                             w.id
@@ -173,9 +178,20 @@ impl Witnesses {
 }
 
 /// Single Witness Node
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+///
+/// Per didwebvh 1.0 § "Witnesses" the `id` of a witness MUST be a `did:key`
+/// identifier (e.g. `did:key:z6Mk...`), NOT a bare multibase key. To guarantee
+/// spec-compliant output regardless of how a caller constructs the value, the
+/// `id` is canonicalized to `did:key:` form on both serialization and
+/// deserialization (see the hand-written [`Serialize`]/[`Deserialize`] impls
+/// below). Use [`Witness::new`] to build one with the same canonicalization.
+///
+/// Canonicalization is a no-op for an already-`did:key:` id, so logs produced
+/// by spec-compliant implementations round-trip byte-for-byte and their
+/// `entryHash` continues to verify.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Witness {
-    /// Multibase-encoded public key identifying this witness node.
+    /// `did:key` identifier of this witness node.
     pub id: Multibase,
 }
 
@@ -185,18 +201,60 @@ impl Display for Witness {
     }
 }
 
+/// Canonicalize a witness identifier to `did:key:` form.
+///
+/// A bare multibase key (`z6Mk...`) gets the `did:key:` prefix prepended; an
+/// id that already starts with `did:key:` is returned unchanged.
+fn canonicalize_witness_id(id: &str) -> String {
+    if id.starts_with("did:key:") {
+        id.to_string()
+    } else {
+        ["did:key:", id].concat()
+    }
+}
+
+impl Serialize for Witness {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Always emit the spec-mandated `did:key:` form, even if `id` was
+        // constructed from a bare multibase key via a struct literal.
+        let mut state = serializer.serialize_struct("Witness", 1)?;
+        state.serialize_field("id", &self.as_did())?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Witness {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct RawWitness {
+            id: String,
+        }
+        let raw = RawWitness::deserialize(deserializer)?;
+        if raw.id.is_empty() {
+            return Err(D::Error::custom("witness id must not be empty"));
+        }
+        Ok(Witness::new(raw.id))
+    }
+}
+
 impl Witness {
+    /// Construct a witness from any key identifier, canonicalizing it to the
+    /// spec-mandated `did:key:` form.
+    ///
+    /// Accepts either a bare multibase key (`z6Mk...`, the `did:key:` prefix is
+    /// prepended) or a full `did:key:z6Mk...` identifier (kept as-is).
+    pub fn new(id: impl Into<String>) -> Self {
+        Witness {
+            id: Multibase::new(canonicalize_witness_id(&id.into())),
+        }
+    }
+
     /// Returns the witness ID as a `did:key:` DID.
     ///
     /// Handles both formats: if the stored ID already starts with `did:key:`,
     /// it is returned as-is; otherwise the prefix is prepended.
     pub fn as_did(&self) -> String {
-        let id = self.id.as_str();
-        if id.starts_with("did:key:") {
-            id.to_string()
-        } else {
-            ["did:key:", id].concat()
-        }
+        canonicalize_witness_id(self.id.as_str())
     }
 
     /// Returns the witness ID as a `did:key:z6...#z6...` verification method reference.
@@ -225,16 +283,21 @@ impl WitnessesBuilder {
         self
     }
 
-    /// Add a single witness by its multibase-encoded public key.
+    /// Add a single witness by its key identifier.
+    ///
+    /// The id is canonicalized to `did:key:` form (a bare multibase key gets
+    /// the `did:key:` prefix prepended).
     pub fn witness(mut self, id: Multibase) -> Self {
-        self.witnesses.push(Witness { id });
+        self.witnesses.push(Witness::new(id.into_inner()));
         self
     }
 
-    /// Add multiple witnesses from an iterator of multibase-encoded public keys.
+    /// Add multiple witnesses from an iterator of key identifiers.
+    ///
+    /// Each id is canonicalized to `did:key:` form.
     pub fn witnesses(mut self, ids: impl IntoIterator<Item = Multibase>) -> Self {
         self.witnesses
-            .extend(ids.into_iter().map(|id| Witness { id }));
+            .extend(ids.into_iter().map(|id| Witness::new(id.into_inner())));
         self
     }
 
@@ -364,6 +427,77 @@ mod tests {
         };
         assert_eq!(value.witnesses().unwrap().len(), 2);
         assert_eq!(value.threshold(), Some(2));
+    }
+
+    /// Issue #42: a `Witness` built from a bare multibase key must serialize
+    /// its `id` as a `did:key:` identifier (spec § "Witnesses"), not the raw
+    /// multikey.
+    #[test]
+    fn test_witness_serializes_id_as_did_key() {
+        let w = Witness {
+            id: Multibase::new("z6Mkrv5Cm2XCLumMPTqooLTCw6YDf421d7VdTziwrZ8vNf4L"),
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(
+            json,
+            r#"{"id":"did:key:z6Mkrv5Cm2XCLumMPTqooLTCw6YDf421d7VdTziwrZ8vNf4L"}"#
+        );
+    }
+
+    /// An already-`did:key:` id serializes unchanged (no double prefix), so
+    /// spec-compliant logs round-trip byte-for-byte and `entryHash` still verifies.
+    #[test]
+    fn test_witness_did_key_id_serializes_unchanged() {
+        let w = Witness::new("did:key:z6Mktest");
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(json, r#"{"id":"did:key:z6Mktest"}"#);
+    }
+
+    /// Deserializing canonicalizes a bare multibase id to `did:key:` form, and
+    /// the value then round-trips stably.
+    #[test]
+    fn test_witness_deserialize_canonicalizes_raw_id() {
+        let w: Witness = serde_json::from_str(r#"{"id":"z6Mktest"}"#).unwrap();
+        assert_eq!(w.id.as_str(), "did:key:z6Mktest");
+        // Re-serialize is stable.
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(json, r#"{"id":"did:key:z6Mktest"}"#);
+    }
+
+    /// An empty witness id is rejected at deserialization.
+    #[test]
+    fn test_witness_deserialize_rejects_empty_id() {
+        let err = serde_json::from_str::<Witness>(r#"{"id":""}"#).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    /// `Witness::new` canonicalizes both bare and prefixed ids.
+    #[test]
+    fn test_witness_new_canonicalizes() {
+        assert_eq!(Witness::new("z6Mktest").id.as_str(), "did:key:z6Mktest");
+        assert_eq!(
+            Witness::new("did:key:z6Mktest").id.as_str(),
+            "did:key:z6Mktest"
+        );
+    }
+
+    /// A bare multibase witness and its `did:key:`-prefixed equivalent are
+    /// treated as duplicates (they serialize identically).
+    #[test]
+    fn test_validate_duplicate_witnesses_mixed_form_error() {
+        let w = Witnesses::Value {
+            threshold: 1,
+            witnesses: vec![
+                Witness {
+                    id: Multibase::new("z6Mktest"),
+                },
+                Witness {
+                    id: Multibase::new("did:key:z6Mktest"),
+                },
+            ],
+        };
+        let err = w.validate().unwrap_err();
+        assert!(err.to_string().contains("more than once"));
     }
 
     /// Tests `as_did()` with a raw multibase key (prepends `did:key:` prefix).


### PR DESCRIPTION
Closes #42. Also refreshes dependencies (incl. `affinidi-data-integrity` 0.6 → 0.7).

## Issue #42 — witness IDs serialized as raw multikey instead of `did:key`

The didwebvh 1.0 spec § "Witnesses" requires each entry in the `witnesses`
array to carry a `did:key` `id` (`did:key:z6Mk…`). A `Witness` built from a
bare multibase key serialized the raw key, producing non-spec,
non-interoperable DID logs — exactly what the reporter observed in the
test-suite `witness-threshold` / `witness-update` vectors
(`"id":"z6Mkrv5Cm2…"` instead of `"id":"did:key:z6Mkrv5Cm2…"`).

### Root cause

`Witness` derived `Serialize`/`Deserialize`, emitting the inner multibase
string verbatim. Whether the `id` ended up as `did:key` or a bare key
depended entirely on how the caller constructed the value — and the
test-suite harness constructs it from `secret.get_public_keymultibase()`
(bare key) via a struct literal.

### Fix

`Witness` now hand-implements `Serialize`/`Deserialize` to **canonicalize
the `id` to `did:key` form on both directions**, so output is spec-compliant
no matter how the value is built (struct literal included). Supporting
changes:

- New `Witness::new()` constructor applies the same canonicalization;
  `WitnessesBuilder` routes through it.
- Duplicate detection in `Witnesses::validate()` compares on the canonical
  form, so a bare key and its `did:key` equivalent are recognized as the
  same witness.

### Why this is safe for existing logs

The log `entryHash` is recomputed from the parsed entry during resolution,
so serialization must round-trip what was published. Canonicalization is a
**no-op for an already-`did:key` id**, so logs produced by spec-compliant
implementations round-trip byte-for-byte and their `entryHash` continues to
verify. All committed test vectors already use `did:key` form; the
`witness_threshold` interop test confirms they still resolve. End-to-end,
`generate_history --witnesses 2` now emits `did:key:` witness ids.

## Dependency refresh

- `affinidi-data-integrity` 0.6 → 0.7 (manifest bump, `major.minor` pin).
- `cargo update` across the rest to latest semver-compatible versions,
  pruning stale duplicate trees (old `reqwest`, `hyper` 0.14, `rustls`
  0.21, `bitflags` 1.x).

## Verification

- `cargo test` — all unit + integration tests pass (incl.
  `test_suite_interop`); `witness_update` remains the pre-existing ignored
  case unrelated to this change.
- `cargo clippy --all-features --lib --tests --examples` — clean.
- `cargo fmt` applied.
- New tests cover: bare key → `did:key` on serialize, `did:key` unchanged,
  deserialize canonicalization + stable re-serialize, empty-id rejection,
  `Witness::new` normalization, and mixed-form duplicate detection.

Version bumped 0.5.3 → 0.5.4 with CHANGELOG entry.