### PR TITLE
feat: feature-gated Arbitrary derives for structure-aware fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1461,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
  "anyhow",
+ "arbitrary",
  "async-trait",
  "base58",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ ignored = ["getrandom"]
 
 [features]
 default = ["network"]
+# Off-by-default `Arbitrary` derives on the public log-entry / parameters types
+# for structure-aware, coverage-guided fuzzing (cargo-fuzz) of the chain
+# verifier. Adds no always-on dependency. See `examples/fuzz_validate.rs`.
+arbitrary = ["dep:arbitrary"]
 ssi = ["dep:ssi", "network"]
 network = ["dep:reqwest"]
 rustls = ["network", "reqwest/rustls"]
@@ -48,6 +52,7 @@ affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 
 ahash = { version = "0.8", features = ["serde"] }
+arbitrary = { version = "1", features = ["derive"], optional = true }
 async-trait = "0.1"
 base58 = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
@@ -103,6 +108,10 @@ required-features = ["network"]
 [[example]]
 name = "generate_large_did"
 required-features = ["network"]
+
+[[example]]
+name = "fuzz_validate"
+required-features = ["arbitrary"]
 
 [lints.rust]
 # Default lints become errors in CI via `cargo clippy -- -D warnings`.

--- a/examples/fuzz_validate.rs
+++ b/examples/fuzz_validate.rs
@@ -1,0 +1,81 @@
+//! Structure-aware fuzz harness for the did:webvh chain verifier.
+//!
+//! With the `arbitrary` feature, the whole log-entry / parameters graph derives
+//! [`arbitrary::Arbitrary`], so a fuzzer can turn a raw `&[u8]` into a
+//! *structurally-valid-but-mutated* chain and drive
+//! [`DIDWebVHState::validate`] directly — far better coverage than byte
+//! mutation, which almost never survives JSON parsing.
+//!
+//! Run it as a normal example over a corpus file (no nightly needed):
+//!
+//! ```sh
+//! cargo run --example fuzz_validate --features arbitrary -- path/to/seed
+//! ```
+//!
+//! To wire it into `cargo-fuzz`, copy [`fuzz_one`] into a libfuzzer target:
+//!
+//! ```ignore
+//! #![no_main]
+//! libfuzzer_sys::fuzz_target!(|data: &[u8]| {
+//!     didwebvh_rs_fuzz::fuzz_one(data);
+//! });
+//! ```
+//!
+//! The contract under fuzz is simple: `validate()` must only ever return
+//! `Ok`/`Err` — it must never panic on attacker-controlled input.
+
+use arbitrary::{Arbitrary, Unstructured};
+use didwebvh_rs::DIDWebVHState;
+use didwebvh_rs::log_entry::LogEntry;
+use didwebvh_rs::log_entry_state::{LogEntryState, LogEntryValidationStatus};
+use didwebvh_rs::parameters::Parameters;
+
+/// One fuzz iteration: build a chain from `data` and run it through the
+/// verifier. Returns early (does nothing) when the bytes can't be coerced
+/// into a plausible chain — that's a miss, not a crash.
+pub fn fuzz_one(data: &[u8]) {
+    let mut u = Unstructured::new(data);
+
+    // Generate a plausible multi-entry chain straight from the bytes.
+    let Ok(entries) = Vec::<LogEntry>::arbitrary(&mut u) else {
+        return;
+    };
+    if entries.is_empty() {
+        return;
+    }
+
+    let mut state = DIDWebVHState::default();
+    for entry in entries {
+        // versionId must parse to a number for the chain walk; if a mutated
+        // entry can't yield one, skip this input rather than fabricate state.
+        let Ok((version_number, _)) = entry.get_version_id_fields() else {
+            return;
+        };
+        state.log_entries_mut().push(LogEntryState {
+            log_entry: entry,
+            version_number,
+            validated_parameters: Parameters::default(),
+            validation_status: LogEntryValidationStatus::NotValidated,
+        });
+    }
+
+    // The property under test: never panic. Both outcomes are acceptable.
+    let _ = state.validate();
+}
+
+fn main() {
+    // Read a single corpus file from argv[1], or stdin if omitted.
+    let data = if let Some(path) = std::env::args().nth(1) {
+        std::fs::read(&path).expect("failed to read corpus file")
+    } else {
+        use std::io::Read;
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .expect("failed to read stdin");
+        buf
+    };
+
+    fuzz_one(&data);
+    println!("ok: validate() did not panic on {} bytes", data.len());
+}

--- a/src/arbitrary_support.rs
+++ b/src/arbitrary_support.rs
@@ -1,0 +1,82 @@
+//! Custom [`arbitrary::Arbitrary`] generators for fields whose types live in
+//! foreign crates and so cannot derive `Arbitrary` directly.
+//!
+//! Only compiled with the off-by-default `arbitrary` feature. These are wired
+//! into the `LogEntry1_0` / `LogEntry1_0Pre` derives via
+//! `#[arbitrary(with = ...)]` so the whole log-entry / parameters graph can be
+//! generated structurally for coverage-guided fuzzing of the chain verifier.
+//!
+//! See the `fuzz_validate` example for how to drive `DIDWebVHState::validate()`
+//! from a `&[u8]` slice.
+
+use affinidi_data_integrity::DataIntegrityProof;
+use arbitrary::{Arbitrary, Result, Unstructured};
+use chrono::{DateTime, FixedOffset};
+use serde_json::{Map, Number, Value};
+
+/// Generate a plausible `versionTime`.
+///
+/// chrono's `DateTime` does not implement `Arbitrary`, and the verifier only
+/// cares that timestamps parse and order monotonically, so we draw a Unix
+/// second in `[0, 2100-01-01)` and convert to a fixed-offset (UTC) datetime.
+pub fn arb_version_time(u: &mut Unstructured) -> Result<DateTime<FixedOffset>> {
+    // 0 ..= 2100-01-01T00:00:00Z
+    let secs = u.int_in_range(0i64..=4_102_444_800)?;
+    let dt = DateTime::from_timestamp(secs, 0).unwrap_or_default();
+    Ok(dt.fixed_offset())
+}
+
+/// Generate a bounded, recursive `serde_json::Value` for the DID-document
+/// `state` field.
+///
+/// Depth is capped so the fuzzer spends its budget on the chain logic rather
+/// than on pathologically deep JSON, and so generation terminates.
+pub fn arb_json_value(u: &mut Unstructured) -> Result<Value> {
+    arb_json_value_depth(u, 4)
+}
+
+fn arb_json_value_depth(u: &mut Unstructured, depth: u32) -> Result<Value> {
+    // At max depth, only emit scalars so recursion always terminates.
+    if depth == 0 {
+        return Ok(Value::String(String::arbitrary(u)?));
+    }
+
+    match u.int_in_range(0u8..=5)? {
+        0 => Ok(Value::Null),
+        1 => Ok(Value::Bool(bool::arbitrary(u)?)),
+        2 => Ok(Value::Number(Number::from(i64::arbitrary(u)?))),
+        3 => Ok(Value::String(String::arbitrary(u)?)),
+        4 => {
+            let len = u.int_in_range(0usize..=4)?;
+            let mut arr = Vec::with_capacity(len);
+            for _ in 0..len {
+                arr.push(arb_json_value_depth(u, depth - 1)?);
+            }
+            Ok(Value::Array(arr))
+        }
+        _ => {
+            let len = u.int_in_range(0usize..=4)?;
+            let mut map = Map::with_capacity(len);
+            for _ in 0..len {
+                map.insert(String::arbitrary(u)?, arb_json_value_depth(u, depth - 1)?);
+            }
+            Ok(Value::Object(map))
+        }
+    }
+}
+
+/// Generate the `proof` vector for a log entry.
+///
+/// `affinidi_data_integrity::DataIntegrityProof` lives in a foreign crate and
+/// has no `Arbitrary` impl, and a *valid* proof requires signing the canonical
+/// log-entry bytes — which can only be done after the rest of the entry is
+/// built. We therefore emit an empty proof set here; a fuzz harness that wants
+/// to exercise the signature-verification path should sign the generated entry
+/// itself (or mutate a seed-corpus entry that already carries proofs).
+///
+/// This still exercises everything up to and including the "is a proof
+/// present / does it authorize this update" gate, plus all of SCID derivation,
+/// entry-hash linkage, and parameter-transition validation.
+pub fn arb_no_proofs(_u: &mut Unstructured) -> Result<Vec<DataIntegrityProof>> {
+    Ok(Vec::new())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,10 @@ use thiserror::Error;
 use tracing::debug;
 
 /// Shared utilities for CLI interactive flows, gated behind the `cli` feature.
+/// Custom [`arbitrary::Arbitrary`] generators for fields whose types live in
+/// foreign crates, gated behind the off-by-default `arbitrary` feature.
+#[cfg(feature = "arbitrary")]
+pub mod arbitrary_support;
 #[cfg(feature = "cli")]
 pub(crate) mod cli_common;
 /// Interactive CLI flow for creating a new DID, gated behind the `cli` feature.
@@ -88,6 +92,7 @@ pub(crate) use affinidi_secrets_resolver::secrets::Secret;
 /// WebVH Specification supports multiple LogEntry versions in the same DID
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Version {
     /// Official v1.0 specification
     #[default]

--- a/src/log_entry/mod.rs
+++ b/src/log_entry/mod.rs
@@ -121,6 +121,7 @@ impl PublicKey for DataIntegrityProof {
 /// [Log Entries](https://identity.foundation/didwebvh/v1.0/#the-did-log-file)
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(untagged)]
 pub enum LogEntry {
     /// Official v1.0 specification

--- a/src/log_entry/spec_1_0.rs
+++ b/src/log_entry/spec_1_0.rs
@@ -13,6 +13,7 @@ use crate::{
 /// Each version of the DID gets a new log entry
 /// [Log Entries](https://identity.foundation/didwebvh/v1.0/#the-did-log-file)
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntry1_0 {
     /// format integer-prev_hash
@@ -20,16 +21,28 @@ pub struct LogEntry1_0 {
 
     /// ISO 8601 date format
     #[serde(serialize_with = "format_version_time")]
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_version_time)
+    )]
     pub version_time: DateTime<FixedOffset>,
 
     /// Parameters for this LogEntry
     pub parameters: Parameters1_0,
 
     /// DID document
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_json_value)
+    )]
     pub state: Value,
 
     /// Data Integrity Proof
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_no_proofs)
+    )]
     pub proof: Vec<affinidi_data_integrity::DataIntegrityProof>,
 }
 

--- a/src/log_entry/spec_1_0_pre.rs
+++ b/src/log_entry/spec_1_0_pre.rs
@@ -15,6 +15,7 @@ use crate::{
 /// Each version of the DID gets a new log entry
 /// [Log Entries](https://identity.foundation/didwebvh/v1.0/#the-did-log-file)
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntry1_0Pre {
     /// format integer-prev_hash
@@ -22,16 +23,28 @@ pub struct LogEntry1_0Pre {
 
     /// ISO 8601 date format
     #[serde(serialize_with = "format_version_time")]
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_version_time)
+    )]
     pub version_time: DateTime<FixedOffset>,
 
     /// Parameters for this LogEntry
     pub parameters: Parameters1_0Pre,
 
     /// DID document
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_json_value)
+    )]
     pub state: Value,
 
     /// Data Integrity Proof
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(
+        feature = "arbitrary",
+        arbitrary(with = crate::arbitrary_support::arb_no_proofs)
+    )]
     pub proof: Vec<affinidi_data_integrity::DataIntegrityProof>,
 }
 

--- a/src/multibase_type.rs
+++ b/src/multibase_type.rs
@@ -11,6 +11,7 @@ use std::fmt;
 /// Serializes transparently as a plain JSON string, so existing JSON formats
 /// are fully preserved.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(transparent)]
 pub struct Multibase(String);
 

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod spec_1_0_pre;
 
 /// Parameters for WebVH DIDs
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Parameters {
     /// SCID (this is often automatically generated))
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/parameters/spec_1_0.rs
+++ b/src/parameters/spec_1_0.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 /// Some(Empty Array/Object) = Cancel the previous Parameters value
 /// Some(Value) = set to new value
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub struct Parameters1_0 {
     /// Is key pre-rotation active?

--- a/src/parameters/spec_1_0_pre.rs
+++ b/src/parameters/spec_1_0_pre.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 /// Some(None) = field was specified, but set to null
 /// Some(Some(value)) = field was specified with a value
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub struct Parameters1_0Pre {
     /// Is key pre-rotation active?

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -75,6 +75,7 @@ impl WitnessVerifyOptions {
 
 /// Witness nodes
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(untagged)]
 pub enum Witnesses {
     /// Active witness configuration with a threshold and list of witness nodes.
@@ -190,6 +191,7 @@ impl Witnesses {
 /// by spec-compliant implementations round-trip byte-for-byte and their
 /// `entryHash` continues to verify.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Witness {
     /// `did:key` identifier of this witness node.
     pub id: Multibase,


### PR DESCRIPTION
## What

Adds an **off-by-default `arbitrary` feature** that derives `arbitrary::Arbitrary` on the public log-entry / parameters graph, so downstream consumers can run **structure-aware, coverage-guided fuzzing** (cargo-fuzz) of the chain verifier.

Closes #44. Requested by the [affinidi-webvh-service](https://github.com/affinidi/affinidi-webvh-service) hosting service, which fuzzes the publish path that bottoms out in `LogEntry::deserialize_string` + `DIDWebVHState::validate()` (their tracking issue: affinidi/affinidi-webvh-service#45).

## Why

Raw byte/string mutation almost never produces input that survives `LogEntry` deserialization, let alone a multi-entry chain whose hashes link — so a fuzzer spends ~all its budget bouncing off the JSON parser and rarely reaches `validate()`, where the interesting bugs live (SCID derivation, entry-hash linkage, parameter transitions, pre-rotation, deactivation tamper detection). With `Arbitrary`, a harness turns a `&[u8]` into a structurally-valid-but-mutated chain and drives the verifier directly.

## Types covered

`LogEntry`, `LogEntry1_0`, `LogEntry1_0Pre`, `Parameters`, `Parameters1_0`, `Parameters1_0Pre`, `Version`, `Multibase`, `Witnesses`, `Witness`.

## Foreign-type fields

Three fields on the log-entry structs have types from foreign crates with no `Arbitrary` impl, handled via `#[arbitrary(with = ...)]` generators in a new gated `arbitrary_support` module:

- `version_time: DateTime<FixedOffset>` — bounded Unix timestamp (`[0, 2100)`).
- `state: serde_json::Value` — depth-bounded recursive JSON.
- `proof: Vec<DataIntegrityProof>` — **emitted empty**. A *valid* proof must be signed over the canonical log-entry bytes, which can only happen after the rest of the entry exists; and `DataIntegrityProof` lives in `affinidi-data-integrity`. This still exercises everything up to the "is a proof present / does it authorize this update" gate plus all of SCID/hash-chain/parameter validation. **This is the main design point I'd like your call on** (see below).

## Safety / impact

- Fully gated behind `#[cfg_attr(feature = "arbitrary", ...)]`; **no change to default builds and no new always-on dependency**.
- `examples/fuzz_validate.rs` (gated on the feature) is a ready-to-copy libfuzzer target body that builds a chain and asserts `validate()` never panics.

## Verification

- `cargo build --features arbitrary` ✅
- `cargo build` (default, example excluded via `required-features`) ✅
- `cargo test --features arbitrary` — **435 passed, 0 failed** ✅
- `cargo clippy --features arbitrary --lib --examples` — clean ✅
- `cargo clippy` (default) — clean ✅
- `cargo run --example fuzz_validate --features arbitrary -- <random bytes>` — no panic ✅

## Open questions for maintainers

1. **Proof generation** — keep proofs empty (current), or add a feature-gated `Arbitrary` to `DataIntegrityProof` upstream in `affinidi-data-integrity` so mutated/invalid proofs can be generated too? Empty keeps this PR self-contained; the latter widens signature-path coverage.
2. **`DIDWebVHState`** — I left it deriving-free and assemble it from a `Vec<LogEntry>` in the example. Happy to derive it directly if you'd prefer a one-call entry point.
3. Want the actual `fuzz/` cargo-fuzz workspace + a CI gate upstreamed here, or kept downstream?

Marking as **draft** pending your steer on (1)–(3).
