### PR TITLE
fix: reject IP-literal hosts at parse time (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # didwebvh-rs Changelog history
 
+## 10th July 2026
+
+### Release 0.5.7 — reject IP-literal hosts at parse time
+
+Fixes the `negative-pct-encoded-ip-host` vector in the
+[didwebvh-test-suite](https://github.com/decentralized-identity/didwebvh-test-suite)
+(closes #47). Not a resolver vulnerability — a percent-encoded IP host was
+already blocked before any HTTP request — but the spec requires the DID to be
+rejected as `invalidDid` by the parser itself, with no fetch attempted.
+
+#### Fixed
+
+- `WebVHURL::parse_did_url()` now rejects a host segment that resolves to an
+  IPv4 or IPv6 literal. The check previously ran `IpAddr::from_str` against the
+  raw, still-percent-encoded segment, so `127%2E0%2E0%2E1` was classified as a
+  domain name and parsing succeeded; `Url::parse` would then decode it back to
+  `127.0.0.1`. The IP-rejection check now goes through `url::Host::parse`, which
+  percent-decodes (case-insensitively, per RFC 3986 §2.1) and applies IDNA
+  before classifying the host. `get_http_url()` / `get_http_whois_url()` /
+  `get_http_files_url()` keep their post-normalisation host check as defense in
+  depth.
+- The same change closes a related parse-time gap: the alternate IPv4 spellings
+  `2130706433`, `0x7f.0.0.1`, `127.1` and `0177.0.0.1` were also accepted as
+  "domain names" (and, like the above, caught only later at URL-build time).
+- A host segment that is empty or that decodes to something which is not a legal
+  URL host (e.g. `a%2Fb`, `1.2.3.4.5`) is now rejected at parse time rather than
+  being carried into `Url::parse`.
+
 ## 29th June 2026
 
 ### Release 0.5.6 — caller-settable `versionTime` on create/update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ rejected as `invalidDid` by the parser itself, with no fetch attempted.
   URL host (e.g. `a%2Fb`, `1.2.3.4.5`) is now rejected at parse time rather than
   being carried into `Url::parse`.
 
+#### Changed
+
+- Refreshed the dependency lockfile to the latest compatible versions (31
+  crates). This clears RUSTSEC-2026-0204 (`crossbeam-epoch` 0.9.18 — invalid
+  pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`),
+  published 6th July 2026 and fixed in 0.9.20.
+
 ## 29th June 2026
 
 ### Release 0.5.6 — caller-settable `versionTime` on create/update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213efdc9d9a0851b2c5d8f9e28d5bfbea3d5109d3fd8e7e7c112b335eb423abb"
+checksum = "10a39562996015e1742b22d23204f76d38c4b609c1d633c0b66031be5e17c847"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -40,11 +40,11 @@ dependencies = [
  "getrandom 0.2.17",
  "k256",
  "ml-dsa",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "p256",
  "p384",
  "p521",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -68,7 +68,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ed25519-dalek",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -133,8 +133,8 @@ dependencies = [
  "base58",
  "base64 0.22.1",
  "getrandom 0.3.4",
- "multibase 0.9.2",
- "rand 0.10.1",
+ "multibase 0.9.3",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -289,9 +289,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert-json-diff"
@@ -328,9 +328,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -338,14 +338,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -369,6 +370,12 @@ dependencies = [
  "const-str",
  "match-lookup",
 ]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base58"
@@ -615,9 +622,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -627,9 +634,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -716,7 +723,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "multihash",
  "serde",
  "serde_bytes",
@@ -811,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -958,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -968,18 +975,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1265,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
@@ -1382,7 +1389,7 @@ dependencies = [
  "bs58 0.4.0",
  "iref",
  "k256",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "p256",
  "serde_json",
  "simple_asn1",
@@ -1473,7 +1480,7 @@ dependencies = [
  "getrandom 0.4.3",
  "percent-encoding",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2509,11 +2516,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2972,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -3057,12 +3064,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -3115,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3167,11 +3175,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3479,7 +3486,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.1",
  "spki 0.8.0",
 ]
 
@@ -3678,15 +3685,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3700,16 +3708,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3769,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3822,6 +3830,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3922,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3934,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4098,7 +4115,7 @@ version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
- "arrayvec 0.7.7",
+ "arrayvec 0.7.8",
  "borsh",
  "bytes",
  "num-traits",
@@ -4111,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4165,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4214,9 +4231,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -4784,7 +4801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5000,7 +5017,7 @@ dependencies = [
  "json-syntax",
  "linked-data",
  "locspan",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "rdf-types",
  "self_cell",
  "serde",
@@ -5040,7 +5057,7 @@ dependencies = [
  "lazy_static",
  "linked-data",
  "locspan",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "p256",
  "p384",
  "pin-project",
@@ -5189,7 +5206,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "linked-data",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "num-bigint",
  "num-derive",
  "num-traits",
@@ -5319,7 +5336,7 @@ checksum = "f870a28eabccd4ae0e807122859bb83e36b87dd096ba01215abce524bddfc247"
 dependencies = [
  "iref",
  "linked-data",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "serde",
  "static-iref",
  "xsd-types",
@@ -5346,7 +5363,7 @@ dependencies = [
  "flate2",
  "iref",
  "log",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "parking_lot",
  "rdf-types",
  "reqwest",
@@ -5378,7 +5395,7 @@ dependencies = [
  "cid",
  "hex",
  "iref",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "serde",
  "serde_ipld_dagjson",
  "serde_json",
@@ -5395,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-vc"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bb7825f7164be57b75eba4e0bc4e9870bd5ebfc8e900e08b3eb582ac653f6b"
+checksum = "7d8edeebaa6f77f0ca218f0ef0e583c7ddae7cb884e6821dec1045758ebf9bd4"
 dependencies = [
  "base64 0.22.1",
  "bitvec 0.20.4",
@@ -5461,7 +5478,7 @@ dependencies = [
  "json-syntax",
  "k256",
  "linked-data",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "p256",
  "p384",
  "pin-project",
@@ -5496,7 +5513,7 @@ dependencies = [
  "hex",
  "iref",
  "linked-data",
- "multibase 0.9.2",
+ "multibase 0.9.3",
  "rdf-types",
  "serde",
  "serde_json",
@@ -5728,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5748,9 +5765,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6102,9 +6119,9 @@ checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8_iter"
@@ -6391,16 +6408,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6418,31 +6426,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -6452,22 +6443,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6476,22 +6455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6500,22 +6467,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6524,22 +6479,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6658,18 +6601,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.6"
+version = "0.5.7"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"

--- a/examples/generate_history.rs
+++ b/examples/generate_history.rs
@@ -246,7 +246,7 @@ pub async fn main() -> Result<()> {
             style("WebVH DID Witness-Proofs Save Duration: ").color256(34),
             style(format!(
                 "{}ms",
-                &end.duration_since(start).unwrap().as_millis()
+                end.duration_since(start).unwrap().as_millis()
             ))
             .color256(141)
         );

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -157,7 +157,7 @@ impl LogEntry {
             );
             return Err(DIDWebVHError::ValidationError(format!(
                 "Signing key ({}) is not authorized",
-                &proof.verification_method
+                proof.verification_method
             )));
         }
 

--- a/src/parameters/spec_1_0.rs
+++ b/src/parameters/spec_1_0.rs
@@ -261,7 +261,7 @@ mod tests {
         let test = Some(Arc::new(vec!["test".to_string()]));
         let diff = Parameters::diff_tri_state::<String>(&None, &test.clone(), "test")
             .expect("Parameters::diff_update_keys error");
-        assert!(diff == test);
+        assert_eq!(diff, test);
     }
 
     #[test]

--- a/src/parameters/spec_1_0_pre.rs
+++ b/src/parameters/spec_1_0_pre.rs
@@ -368,7 +368,7 @@ mod tests {
         let test = Some(Arc::new(vec!["test".to_string()]));
         let diff = Parameters::diff_tri_state::<String>(&None, &test.clone(), "test")
             .expect("Parameters::diff_update_keys error");
-        assert!(diff == test);
+        assert_eq!(diff, test);
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,7 +1,6 @@
 use crate::DIDWebVHError;
 use chrono::{DateTime, FixedOffset};
 use std::fmt::{Display, Formatter};
-use std::net::IpAddr;
 use url::Url;
 
 type QueryPairs = (Option<String>, Option<DateTime<FixedOffset>>, Option<u32>);
@@ -104,8 +103,8 @@ impl WebVHURL {
         let scid = parts[0].to_string();
 
         // Percent-encoding is case-insensitive (RFC 3986 §2.1). Matching only the
-        // uppercase form would leave `127.0.0.1%3a8080` as the "domain", which then
-        // slips past `reject_ip_address()` because it no longer parses as a bare IP.
+        // uppercase form would leave `example.com%3a8080` glued together as the
+        // "domain" and the port would be silently dropped.
         let (domain, port) = match parts[1]
             .split_once("%3A")
             .or_else(|| parts[1].split_once("%3a"))
@@ -261,13 +260,12 @@ impl WebVHURL {
 
     /// Re-check the host *after* `Url::parse` has normalised it.
     ///
-    /// `reject_ip_address()` runs on the raw DID segment, which has not been
-    /// percent-decoded — so `127%2E0%2E0%2E1` does not parse as an `IpAddr`
-    /// and slips through. `Url::parse` then decodes it to `127.0.0.1` and
-    /// the resolver would happily fetch from localhost (or
-    /// `169.254.169.254`, etc.). This check looks at what the HTTP client
-    /// will actually connect to, after all of the `url` crate's host
-    /// normalisation, and rejects any IP literal.
+    /// Defense in depth: `reject_ip_address()` already rejects IP literals at
+    /// parse time, but a `WebVHURL` can also be constructed field-by-field, and
+    /// the path/port components are re-joined into a string before being handed
+    /// back to `Url::parse`. This is the last check before the resolver hands
+    /// the URL to an HTTP client, so it looks at the host that client will
+    /// actually connect to.
     fn reject_ip_host(url: &Url) -> Result<(), DIDWebVHError> {
         match url.host() {
             Some(url::Host::Ipv4(ip)) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
@@ -285,18 +283,28 @@ impl WebVHURL {
 
     /// Rejects IP addresses (both IPv4 and IPv6) as the domain component.
     /// The did:webvh spec requires domain names, not IP addresses.
+    ///
+    /// The host is run through `url::Host::parse` rather than `IpAddr::from_str`
+    /// so that the rule is applied to whatever the HTTP client will ultimately
+    /// connect to. `Host::parse` percent-decodes (case-insensitively, per
+    /// RFC 3986 §2.1), applies IDNA, and canonicalises the alternate IPv4
+    /// spellings (`2130706433`, `0x7f.0.0.1`, `127.1`) — all of which a check
+    /// against the raw DID segment would wave through as a "domain name",
+    /// only for `Url::parse` to normalise them back into a loopback or
+    /// link-local address later.
     fn reject_ip_address(domain: &str) -> Result<(), DIDWebVHError> {
-        // Strip brackets for IPv6 (e.g., "[::1]" -> "::1")
-        let bare = domain
-            .strip_prefix('[')
-            .and_then(|s| s.strip_suffix(']'))
-            .unwrap_or(domain);
-        if bare.parse::<IpAddr>().is_ok() {
-            return Err(DIDWebVHError::InvalidMethodIdentifier(format!(
-                "Invalid URL: IP addresses are not allowed, use a domain name instead: {domain}",
-            )));
+        match url::Host::parse(domain) {
+            Ok(url::Host::Domain(_)) => Ok(()),
+            Ok(url::Host::Ipv4(ip)) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                "Invalid URL: IP addresses are not allowed, use a domain name instead: {ip}",
+            ))),
+            Ok(url::Host::Ipv6(ip)) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                "Invalid URL: IP addresses are not allowed, use a domain name instead: {ip}",
+            ))),
+            Err(err) => Err(DIDWebVHError::InvalidMethodIdentifier(format!(
+                "Invalid URL: host ({domain}) is not a valid domain name: {err}",
+            ))),
         }
-        Ok(())
     }
 
     /// Parses URL query parameters and returns:
@@ -568,12 +576,15 @@ mod tests {
         assert!(WebVHURL::parse_did_url("did:webvh:scid:127.0.0.1%3a8080").is_err());
     }
 
-    /// Regression: `reject_ip_address()` runs on the raw, still-percent-
-    /// encoded domain segment, so `127%2E0%2E0%2E1` is not an `IpAddr` and
-    /// passes — but `Url::parse` then decodes it to `127.0.0.1` and the
-    /// resolver would fetch from localhost. `get_http_url` now re-checks
-    /// the host *after* parse so the encoding the attacker chooses no
-    /// longer matters.
+    /// Regression: `reject_ip_address()` used to run `IpAddr::from_str` on the
+    /// raw, still-percent-encoded domain segment, so `127%2E0%2E0%2E1` was not
+    /// an `IpAddr` and passed — `Url::parse` then decoded it to `127.0.0.1` and
+    /// the resolver would fetch from localhost. The check now goes through
+    /// `url::Host::parse`, which decodes before classifying, so the DID is
+    /// rejected at parse time with no fetch attempted.
+    ///
+    /// Matches the `negative-pct-encoded-ip-host` vector in didwebvh-test-suite,
+    /// which expects `invalidDid` from the parser itself.
     #[test]
     fn url_rejects_pct_encoded_ip_host() {
         for did in [
@@ -582,16 +593,50 @@ mod tests {
             "did:webvh:scid:169%2E254%2E169%2E254",
             "did:webvh:scid:127%2E0%2E0%2E1%3A8080",
         ] {
-            let parsed = WebVHURL::parse_did_url(did).expect("parse stage doesn't decode");
-            let err = parsed
-                .get_http_url(None)
-                .expect_err("post-parse host check must reject the decoded IP");
+            let err = WebVHURL::parse_did_url(did)
+                .err()
+                .expect("must be rejected at parse time");
             assert!(
                 err.to_string().contains("IP addresses are not allowed"),
                 "{did} -> {err}"
             );
-            assert!(parsed.get_http_whois_url().is_err());
-            assert!(parsed.get_http_files_url().is_err());
+        }
+    }
+
+    /// The raw-string check also missed every non-dotted-quad spelling of an
+    /// IPv4 address. `Url::parse` canonicalises all of these to `127.0.0.1`.
+    #[test]
+    fn url_rejects_alternate_ipv4_spellings() {
+        for did in [
+            "did:webvh:scid:2130706433",
+            "did:webvh:scid:0x7f.0.0.1",
+            "did:webvh:scid:127.1",
+            "did:webvh:scid:0177.0.0.1",
+        ] {
+            let err = WebVHURL::parse_did_url(did)
+                .err()
+                .expect("must be rejected at parse time");
+            assert!(
+                err.to_string().contains("IP addresses are not allowed"),
+                "{did} -> {err}"
+            );
+        }
+    }
+
+    /// A host segment that survives the DID split but is not a legal URL host
+    /// (empty, or containing a forbidden character once decoded) must also be
+    /// rejected rather than carried into `Url::parse` later.
+    #[test]
+    fn url_rejects_malformed_host() {
+        for did in [
+            "did:webvh:scid:",
+            "did:webvh:scid:a%2Fb",
+            "did:webvh:scid:1.2.3.4.5",
+        ] {
+            assert!(
+                WebVHURL::parse_did_url(did).is_err(),
+                "{did} should be rejected"
+            );
         }
     }
 


### PR DESCRIPTION
Closes #47.

## Why the test was failing

The `negative-pct-encoded-ip-host` vector is a URL-only test — no network call is made. The harness pulls the `resolve-did` DIDs out of `script.yaml` and passes only if the parser rejects each one:

```rust
if WebVHURL::parse_did_url(did).is_ok() {
    fail_reason = Some(format!("negative-pct-encoded-ip-host: {did}"));
```

Ours returned `Ok`, because `reject_ip_address()` ran `IpAddr::from_str` against the **raw, still-percent-encoded** host segment. `"127%2E0%2E0%2E1".parse::<IpAddr>()` fails, so the segment was classified as a domain name.

**This was never a resolver vulnerability.** `get_http_url()`, `get_http_whois_url()` and `get_http_files_url()` all call `reject_ip_host()` after `Url::parse` has decoded `%2E` → `.`, so no request to `127.0.0.1` or `169.254.169.254` was ever issued. But the vector's README is explicit that the check must happen at parse time (`invalidDid` — "parse-time failure, no fetch attempted"), which is where TypeScript, Java and Dart put theirs. That difference was the entire failure.

## The fix

Route the IP check through `url::Host::parse` instead of `IpAddr::from_str`. It percent-decodes (case-insensitively, per RFC 3986 §2.1), applies IDNA, and canonicalises the numeric IPv4 forms — i.e. it classifies the host the HTTP client will actually connect to:

```
       127%2E0%2E0%2E1 -> Ok(Ipv4(127.0.0.1))
            2130706433 -> Ok(Ipv4(127.0.0.1))
            0x7f.0.0.1 -> Ok(Ipv4(127.0.0.1))
                 127.1 -> Ok(Ipv4(127.0.0.1))
           example.com -> Ok(Domain("example.com"))
             localhost -> Ok(Domain("localhost"))
```

This also closes two adjacent parse-time gaps the raw-string check had:

- **Alternate IPv4 spellings.** `2130706433`, `0x7f.0.0.1`, `127.1`, `0177.0.0.1` were all accepted as "domain names" (again, caught downstream at URL-build time, so no SSRF — but they'd fail a parse-time vector too).
- **Malformed hosts.** An empty host segment, or one that decodes to something illegal (`a%2Fb`, `1.2.3.4.5`), is now rejected up front rather than carried into `Url::parse`.

`reject_ip_host()` is kept in the URL builders as defense in depth — `WebVHURL` has public fields and can be constructed without going through the parser.

## Verification

Reproduced the harness's exact assertion against this branch, using the real `script.yaml` from didwebvh-test-suite:

**Before** (`main`):
```
negative-pct-encoded-ip-host: FAIL - URL parser accepted invalid DID: did:webvh:Qm00...00:169%2E254%2E169%2E254
```

**After**:
```
  rejected: did:webvh:Qm00...00:127%2E0%2E0%2E1
    -> Invalid method identifier: Invalid URL: IP addresses are not allowed, use a domain name instead: 127.0.0.1
  rejected: did:webvh:Qm00...00:127%2e0%2e0%2e1
    -> Invalid method identifier: Invalid URL: IP addresses are not allowed, use a domain name instead: 127.0.0.1
  rejected: did:webvh:Qm00...00:169%2E254%2E169%2E254
    -> Invalid method identifier: Invalid URL: IP addresses are not allowed, use a domain name instead: 169.254.169.254

negative-pct-encoded-ip-host: PASS (3 DIDs rejected)
```

Full suite green (438 unit tests + integration), `cargo fmt --check` and `cargo clippy --all-features --lib --tests` clean.

## Compatibility

`parse_did_url()` now returns `Err` for inputs it previously accepted (IP-literal and malformed hosts). Every one of those inputs already failed at `get_http_url()`, so any caller that parsed and then resolved sees the same outcome — only earlier, and with a clearer error. Bumped to v0.5.7.

## Note on the existing test

`url_rejects_pct_encoded_ip_host` previously asserted the old behavior explicitly (`.expect("parse stage doesn't decode")`), so it needed inverting rather than just extending — it now asserts parse-time rejection.