### PR TITLE
chore: release 0.6.0 — affinidi-did-common 0.4 + pre-release audit fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,25 +68,24 @@ jobs:
       #
       # Vulnerabilities (advisories with severity):
       # - RUSTSEC-2023-0071: rsa 0.6.1 Marvin Attack timing side-channel (via ssi-jwk)
-      # - RUSTSEC-2026-0098: rustls-webpki 0.101.7 URI name constraints (via reqwest 0.11)
-      # - RUSTSEC-2026-0099: rustls-webpki 0.101.7 wildcard name constraints (via reqwest 0.11)
-      # - RUSTSEC-2026-0104: rustls-webpki 0.101.7 CRL parse panic (via reqwest 0.11)
       #
       # Unmaintained warnings (no CVE, advisory category = "unmaintained"):
       # - RUSTSEC-2021-0127: serde_cbor unmaintained (via ssi-vc-jose-cose)
-      # - RUSTSEC-2024-0370: proc-macro-error unmaintained (via did-tz)
+      # - RUSTSEC-2024-0370: proc-macro-error unmaintained (via linked-data-derive)
       # - RUSTSEC-2024-0388: derivative unmaintained (via ssi-jwk)
-      # - RUSTSEC-2025-0134: rustls-pemfile unmaintained (via reqwest 0.11)
+      #
+      # The four reqwest 0.11-rooted entries (RUSTSEC-2026-0098/0099/0104
+      # rustls-webpki, RUSTSEC-2025-0134 rustls-pemfile) were dropped when
+      # this crate moved to reqwest 0.13 — that dep chain is gone and a
+      # current audit no longer reports them. Do not re-add an --ignore
+      # without confirming the advisory actually fires; stale ignores
+      # silently mask the advisory if the dep ever returns.
       #
       # Re-audit when upstream `ssi` drops the affected dep chains
-      # (most are rooted in ssi-jwk / ssi-vc-jose-cose / reqwest 0.11).
+      # (all remaining entries are rooted in ssi-jwk / ssi-vc-jose-cose).
       - run: >-
           cargo audit
           --ignore RUSTSEC-2023-0071
           --ignore RUSTSEC-2024-0388
           --ignore RUSTSEC-2024-0370
-          --ignore RUSTSEC-2025-0134
           --ignore RUSTSEC-2021-0127
-          --ignore RUSTSEC-2026-0098
-          --ignore RUSTSEC-2026-0099
-          --ignore RUSTSEC-2026-0104

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # didwebvh-rs Changelog history
 
+## 19th July 2026
+
+### Release 0.5.8 — affinidi-did-common 0.4
+
+Bumps the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`. No code
+changes were required: `Document` gained a typed `also_known_as` field, which is
+additive, and this crate does not construct `Document` by struct literal nor
+re-export it from its public API.
+
+`affinidi-data-integrity` is pinned to `"0.7.7"` in the same change. It is a
+transitive consumer of `affinidi-did-common` and, left at `"0.7"`, resolves to
+the published `0.7.6` which still requires `"0.3"` — putting a second copy of
+`affinidi-did-common` in the graph for exactly the same reason.
+
+This release must land on crates.io **before** `affinidi-did-common 0.4.0`
+propagates to consumers. Per affinidi-tdk-rs ADR 0003 §3, a minor bump of
+`affinidi-did-common` invalidates the `[patch.crates-io]` redirect held by any
+external consumer still requiring `"0.3"`; leaving this crate on `"0.3"` would
+put two copies of `affinidi-did-common` in the dependency graph and break
+downstream builds with duplicate-type errors.
+
 ## 10th July 2026
 
 ### Release 0.5.7 — reject IP-literal hosts at parse time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,117 @@
 
 ## 19th July 2026
 
-### Release 0.5.8 — affinidi-did-common 0.4
+### Release 0.6.0 — affinidi-did-common 0.4, pre-release audit fixes
+
+Originally scoped as 0.5.8 (the `affinidi-did-common` bump alone). Promoted to
+0.6.0 because the audit fixes below include `#[non_exhaustive]` on already
+published public enums, which is a breaking change for downstream code that
+`match`es them exhaustively — shipping that in a patch release would violate
+semver.
+
+#### Breaking
+
+- `DIDWebVHError`, `URLType` and `LogEntryValidationStatus` are now
+  `#[non_exhaustive]`. Downstream `match` expressions over these types must add
+  a wildcard `_ =>` arm. `DIDWebVHError` is the crate's primary public error
+  type and gains variants as the spec evolves; making it non-exhaustive now
+  means those additions no longer require a major bump every time. The struct
+  variants `NetworkError` and `ResponseTooLarge` can likewise gain fields.
+
+#### Fixed
+
+- `update_did()` no longer silently discards `portable` on the migration path.
+  `do_migrate` carried its own copy-pasted parameter-overlay block that omitted
+  the `portable` arm, so `.migrate_to(..).disable_portability()` built and ran
+  successfully while dropping the portability change. Both paths now share a
+  single `apply_param_overrides` helper, so the two cannot drift again.
+- The successor-version check in `LogEntry::verify_log_entry()` no longer
+  overflows on a `versionId` of `u32::MAX`. The value is parsed from the
+  untrusted log and `verify_log_entry` is public, so the previous bare `id + 1`
+  was reachable with attacker-controlled input: a panic in debug builds, and a
+  silent wrap to `0` in release builds that would have let a chain restart its
+  numbering. Now returns a `ValidationError`.
+- The interactive CLI update flow no longer panics when no authorization keys
+  are active. `active_update_keys[0]` was indexed unconditionally in two places;
+  a deactivated DID (empty `update_keys`) or deselecting every key in the
+  key-selection prompt produced an index-out-of-bounds panic instead of an
+  error. Both sites now return a `DIDError` explaining the condition.
+
+#### Changed
+
+- `WebVHURL` now derives `Debug`, `PartialEq` and `Eq`; `URLType` additionally
+  derives `Eq`. `WebVHURL` previously derived only `Clone`, so consumers could
+  not derive `Debug` on any type containing one, compare two, or call
+  `.expect_err()` on a `Result` returning one.
+- Direct dependencies refreshed: `async-trait` 0.1.91, `serde` 1.0.229,
+  `thiserror` 2.0.19, `tokio` 1.53.0, plus `anyhow`/`clap` on the dev side.
+- The CI security-audit job no longer passes four stale `--ignore` flags
+  (`RUSTSEC-2026-0098/0099/0104`, `RUSTSEC-2025-0134`). Those advisories were
+  rooted in the reqwest 0.11 dep chain, which disappeared when this crate moved
+  to reqwest 0.13; a current audit does not report them. Stale ignores silently
+  mask an advisory if the dependency ever returns.
+
+#### Documentation
+
+- Corrected two README examples that did not compile: `create_did()` was shown
+  without `.await`, and `CreateDIDResult` was shown accessing `did` /
+  `log_entry` / `witness_proofs` as fields when they are `pub(crate)` and
+  reached via accessor methods. A third example built `update_keys` from a bare
+  `String` rather than a `Multibase`.
+- Fixed the MSRV badge (1.94.0 → 1.95.0, the real `rust-version`), a dead
+  `LICENSE-APACHE` link, stale version numbers in four install snippets, two
+  rustdoc intra-doc links that render broken in plain Markdown, and an
+  incomplete prelude listing.
+- Doc examples previously marked ```` ```ignore ```` are now ```` ```no_run ````
+  where they can be, so they are type-checked on every `cargo test --doc`
+  instead of being skipped. The two broken README examples above existed
+  precisely because nothing compiled them.
+
+#### Testing
+
+- `tests/revoked.rs` no longer writes to fixed paths under the git-tracked
+  `tests/test_vectors/`. `LogEntry::save_to_file` **appends**, and the files
+  were only removed after the assertion, so any failed or interrupted run left
+  a file that the next run appended to — producing a corrupt chain and a
+  spurious failure. Each test now gets its own `TempDir`, removed on drop
+  including on panic.
+- Added regression coverage for the `portable`-on-migrate fix (verified to fail
+  without it), for the other overlay fields on the migrate path, and for the
+  `u32::MAX` successor-version boundary.
+- The `witness-update` interop vector is no longer `#[ignore]`d. It is now an
+  active test asserting that this resolver **rejects** it — see below. The
+  interop suite runs 13 of 13 scenarios with nothing ignored.
+
+#### Conformance note — `witness-update` test vector
+
+The didwebvh-test-suite `witness-update` vector expects a log entry that lowers
+its *own* witness configuration (from `{threshold: 2, witnesses: [A, B]}` to
+`{threshold: 1, witnesses: [A]}`, supplying one proof) to resolve successfully.
+This resolver rejects it, and that is deliberate.
+
+didwebvh 1.0 requires proofs "from a threshold of the **then active**
+witnesses", and states that "changing the witnesses for a DID take effect only
+*after* the entry in which they are defined has been published". The
+then-active configuration for that entry is the previous entry's — threshold 2
+— and only one proof is present.
+
+Evaluating the entry against the new configuration it declares would make
+witnessing bypassable: an attacker holding a compromised update key could
+publish `{threshold: 1, witnesses: [attacker]}`, sign the one required proof
+themselves, and have it accepted. Bounding exactly that compromise is the
+purpose of the witness mechanism, so the stricter reading is the correct one.
+
+The divergence should be raised against didwebvh-test-suite. The test that
+pins this behaviour is `witness_update_rejects_self_lowered_threshold` in
+`tests/test_suite_interop.rs`; if it ever starts failing because the entry
+resolves, that is a security regression rather than fixture drift.
+
+Note also that this test's previous `#[ignore]` reason misdiagnosed the cause
+as "witness proof signature on entry 2 fails verification" and pointed at a
+`tasks/todo.md` that does not exist in the repository. The signature verifies
+correctly; it is the threshold that is not met.
+
+#### Dependencies
 
 Bumps the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`. No code
 changes were required: `Document` gained a typed `also_known_as` field, which is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a39562996015e1742b22d23204f76d38c4b609c1d633c0b66031be5e17c847"
+checksum = "39e7ea1c5a572bab1a8af43b517e4a7674d57c061dd75e61799ec9fc9f356b4e"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -50,16 +50,16 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "slh-dsa",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902b3bd9bad4c8b492c9282b7771c53da512422e546efed7501e3b45afa17009"
+checksum = "2ab562d8232a2837c8fd23c06688ac5dc3ed2f8fdf5b503344b50677d3ef2a38"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -73,23 +73,23 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f36c0ae3c4991f7d059358e2d9a637c826110df3c72d4ce8caf20204ed55647"
+checksum = "c185bf5127185198ea6c6f5d005fef7e2bc1e03af41866eb9fb2bbff749c2bff"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
  "base64 0.22.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "x25519-dalek",
  "zeroize",
@@ -103,7 +103,7 @@ checksum = "0c4100740ddcda25754956cbc48350d4ae358c1086390bbcf457b6ea7b2b07ff"
 dependencies = [
  "bs58 0.5.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unsigned-varint 0.8.0",
  "zeroize",
 ]
@@ -117,7 +117,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -138,7 +138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -305,13 +305,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -328,9 +328,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -424,9 +424,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -521,15 +521,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -634,9 +634,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -661,9 +661,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -761,7 +761,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1162,7 +1162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1221,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ dependencies = [
  "ssi-dids-core",
  "ssi-jwk",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1358,7 +1358,7 @@ dependencies = [
  "ssi-jws",
  "ssi-jwt",
  "ssi-verification-methods",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-verification-methods",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-multicodec",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ dependencies = [
  "ssi-dids-core",
  "ssi-jwk",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-jws",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -1455,12 +1455,12 @@ dependencies = [
  "iref",
  "reqwest",
  "ssi-dids-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -1488,7 +1488,8 @@ dependencies = [
  "serde_with 3.21.0",
  "sha2 0.11.0",
  "ssi",
- "thiserror 2.0.18",
+ "tempfile",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1537,7 +1538,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1621,7 +1622,7 @@ dependencies = [
  "enum-ordinalize 4.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1676,7 +1677,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1696,7 +1697,7 @@ checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1712,7 +1713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1821,9 +1822,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1836,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1846,15 +1847,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1863,38 +1864,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2103,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2113,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2477,7 +2478,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2492,7 +2493,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2511,7 +2512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2893,7 +2894,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static-iref",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 1.0.69",
 ]
 
@@ -2965,7 +2966,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3007,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3142,7 +3143,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3260,7 +3261,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3307,7 +3308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
 ]
 
@@ -3439,7 +3440,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3611,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3628,7 +3629,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3677,7 +3678,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3700,7 +3701,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3717,14 +3718,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3755,9 +3756,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3767,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3919,29 +3920,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3951,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4119,7 +4120,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -4151,14 +4152,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4208,7 +4209,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4261,9 +4262,9 @@ checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "ryu_floating_decimal"
@@ -4364,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -4376,9 +4377,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4406,22 +4407,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -4465,7 +4466,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
 dependencies = [
- "ryu-js 1.0.2",
+ "ryu-js 1.0.3",
  "serde",
  "serde_json",
 ]
@@ -4550,7 +4551,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4562,7 +4563,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4674,15 +4675,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4760,9 +4761,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4770,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -4893,7 +4894,7 @@ dependencies = [
  "ssi-vc",
  "ssi-vc-jose-cose",
  "ssi-verification-methods",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4909,7 +4910,7 @@ dependencies = [
  "ssi-crypto",
  "ssi-eip712",
  "ssi-json-ld",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4927,7 +4928,7 @@ dependencies = [
  "async-trait",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4941,7 +4942,7 @@ dependencies = [
  "serde",
  "ssi-claims-core",
  "ssi-crypto",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4962,7 +4963,7 @@ dependencies = [
  "p256",
  "p384",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.8.7",
  "ripemd160",
  "serde",
  "sha2 0.10.9",
@@ -4997,7 +4998,7 @@ dependencies = [
  "ssi-rdf",
  "ssi-security",
  "ssi-verification-methods",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5032,7 +5033,7 @@ dependencies = [
  "ssi-security",
  "ssi-verification-methods",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xsd-types",
 ]
 
@@ -5061,7 +5062,7 @@ dependencies = [
  "p256",
  "p384",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rdf-types",
  "self_cell",
  "serde",
@@ -5083,7 +5084,7 @@ dependencies = [
  "ssi-security",
  "ssi-verification-methods",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xsd-types",
 ]
 
@@ -5106,7 +5107,7 @@ dependencies = [
  "ssi-core",
  "ssi-json-ld",
  "ssi-rdf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -5125,7 +5126,7 @@ dependencies = [
  "did-web",
  "ssi-dids-core",
  "ssi-jwk",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5150,7 +5151,7 @@ dependencies = [
  "ssi-jws",
  "ssi-verification-methods-core",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5188,7 +5189,7 @@ dependencies = [
  "ssi-contexts",
  "ssi-rdf",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5212,7 +5213,7 @@ dependencies = [
  "num-traits",
  "p256",
  "p384",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_jcs",
@@ -5241,7 +5242,7 @@ dependencies = [
  "linked-data",
  "p256",
  "p384",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -5316,7 +5317,7 @@ checksum = "0eadfb39ff2554976db49985fd8b61ddf46829acc15ca528831efc5f175ba6ed"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5325,7 +5326,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-jws",
  "ssi-jwt",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5379,7 +5380,7 @@ dependencies = [
  "ssi-vc",
  "ssi-vc-jose-cose",
  "ssi-verification-methods",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xsd-types",
 ]
 
@@ -5407,7 +5408,7 @@ dependencies = [
  "ssi-jws",
  "ssi-jwt",
  "ssi-verification-methods",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5437,7 +5438,7 @@ dependencies = [
  "ssi-rdf",
  "ssi-verification-methods",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xsd-types",
 ]
 
@@ -5458,7 +5459,7 @@ dependencies = [
  "ssi-jwt",
  "ssi-sd-jwt",
  "ssi-vc",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xsd-types",
 ]
 
@@ -5499,7 +5500,7 @@ dependencies = [
  "ssi-security",
  "ssi-verification-methods-core",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5524,7 +5525,7 @@ dependencies = [
  "ssi-jwk",
  "ssi-jws",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5548,7 +5549,7 @@ dependencies = [
  "ssi-rdf",
  "ssi-verification-methods",
  "static-iref",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5565,7 +5566,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5584,7 +5585,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2 0.10.9",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 1.0.69",
 ]
 
@@ -5625,9 +5626,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5651,7 +5663,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5691,7 +5703,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5705,11 +5717,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5720,25 +5732,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5804,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5819,9 +5831,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -5834,13 +5846,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5887,9 +5899,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -5970,7 +5982,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6137,9 +6149,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6259,7 +6271,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6294,9 +6306,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6323,7 +6335,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6353,7 +6365,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6364,7 +6376,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6486,9 +6498,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6595,7 +6607,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6616,7 +6628,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6636,7 +6648,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6657,7 +6669,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6690,11 +6702,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.8"
+version = "0.6.0"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"
@@ -33,6 +33,10 @@ cli = ["dep:dialoguer", "dep:console"]
 # coverage-guided fuzzing of the chain verifier (see the `fuzz/` crate). No
 # effect on default builds and no new always-on dependency. See issue #44.
 arbitrary = ["dep:arbitrary"]
+# Enables the nightly-only `did_benchmarks_nightly` bench (`#![feature(test)]`).
+# Requires a nightly toolchain; keeping it off by default is what lets
+# `--all-targets` succeed on stable.
+nightly = []
 # Experimental post-quantum cryptosuites (ML-DSA-{44,65,87}, SLH-DSA-128).
 # Not yet in the didwebvh 1.0 spec — enable only for interop testing with
 # other PQC-aware implementations. See README "Experimental PQC support"
@@ -93,6 +97,7 @@ tracing-subscriber = { version = "0.3", features = [
   "json",
   "valuable",
 ] }
+tempfile = "3.27.0"
 
 [[example]]
 name = "resolve"
@@ -166,5 +171,11 @@ unnecessary_semicolon = "allow"                     # Trailing `;` on `let _ = e
 name = "did_benchmarks"
 harness = false
 
+# Uses `#![feature(test)]`, so it only builds on a nightly toolchain. Gated
+# behind an off-by-default feature so `cargo check/clippy --all-targets` works
+# on stable — without the gate, --all-targets fails with E0554 on stable and
+# every invocation has to spell out `--tests --examples` to route around it.
+# Run with: cargo +nightly bench --features nightly
 [[bench]]
 name = "did_benchmarks_nightly"
+required-features = ["nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didwebvh-rs"
-version = "0.5.7"
+version = "0.5.8"
 description = "Implementation of the did:webvh method in Rust"
 repository = "https://github.com/decentralized-identity/didwebvh-rs"
 edition = "2024"
@@ -48,8 +48,8 @@ experimental-pqc = [
 ]
 
 [dependencies]
-affinidi-data-integrity = { version = "0.7" }
-affinidi-did-common = "0.3"
+affinidi-data-integrity = { version = "0.7.7" }
+affinidi-did-common = "0.4"
 affinidi-secrets-resolver = "0.5"
 
 ahash = { version = "0.8", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/didwebvh-rs.svg)](https://crates.io/crates/didwebvh-rs)
 [![Documentation](https://docs.rs/didwebvh-rs/badge.svg)](https://docs.rs/didwebvh-rs)
-[![Rust](https://img.shields.io/badge/rust-1.94.0%2B-blue.svg?maxAge=3600)](https://github.com/decentralized-identity/didwebvh-rs)
+[![Rust](https://img.shields.io/badge/rust-1.95.0%2B-blue.svg?maxAge=3600)](https://github.com/decentralized-identity/didwebvh-rs)
 
 A complete implementation of the [did:webvh](https://identity.foundation/didwebvh/v1.0/)
 method in Rust. Supports version 1.0 spec.
@@ -47,7 +47,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-didwebvh-rs = "0.5.0"
+didwebvh-rs = "0.6.0"
 ```
 
 Then:
@@ -62,18 +62,31 @@ webvh.load_log_entries_from_file("did.jsonl")?;
 ```
 
 The `prelude` module re-exports the most commonly needed types:
-`DIDWebVHError`, `DIDWebVHState`, `LogEntryMethods`, `Parameters`,
-`ValidationReport`, `TruncationReason`, `CreateDIDConfig`, `create_did`,
-`UpdateDIDConfig`, `update_did`, `Witnesses`, `WitnessProofCollection`,
-`Signer`, `KeyType`, `Secret`, `async_trait`, and the `generate_did_key`
-helper.
 
-> **Version skew note (0.5.0):** third-party types (`Signer`, `KeyType`,
-> `Secret`, `async_trait`) and the whole-crate re-export of
-> `affinidi_secrets_resolver` are no longer exposed at the crate root.
-> Reach for them via `prelude::*` or depend on the source crates in your
-> own Cargo.toml. This shields your build from version skew introduced
-> by whatever didwebvh-rs happens to pin.
+- Always available: `DIDWebVHError`, `DIDWebVHState`, `Multibase`,
+  `TruncationReason`, `ValidationReport`, `CreateDIDConfig`, `create_did`,
+  `UpdateDIDConfig`, `update_did`, `LogEntryMethods`, `Parameters`,
+  `Witnesses`, `WitnessProofCollection`, and the `generate_did_key` helper.
+- Re-exported from third-party crates: `Signer`
+  (`affinidi_data_integrity`), `KeyType` and `Secret`
+  (`affinidi_secrets_resolver`), and `async_trait`.
+- Requires the `network` feature: `ResolveOptions`.
+- Requires the `cli` feature: `InteractiveCreateConfig`,
+  `InteractiveCreateResult`, `interactive_create_did`,
+  `InteractiveUpdateConfig`, `InteractiveUpdateResult`, `UpdateOperation`,
+  `UpdateSecrets`, `interactive_update_did`.
+
+> **Version skew note:** third-party types (`Signer`, `KeyType`, `Secret`,
+> `async_trait`) are not exposed at the crate root. Reach for them via
+> `prelude::*` or depend on the source crates in your own Cargo.toml. This
+> shields your build from version skew introduced by whatever didwebvh-rs
+> happens to pin.
+>
+> The whole-crate `didwebvh_rs::affinidi_secrets_resolver` re-export was
+> deprecated in 0.5.0 and **removed in 0.6.0**. Replace
+> `didwebvh_rs::affinidi_secrets_resolver::secrets::Secret` with
+> `didwebvh_rs::prelude::Secret`, or add `affinidi-secrets-resolver` to your
+> own `Cargo.toml` if you need its full surface.
 
 ## Feature Flags
 
@@ -91,7 +104,7 @@ To use the library without network support (e.g. for local file validation only)
 
 ```toml
 [dependencies]
-didwebvh-rs = { version = "0.3.0", default-features = false }
+didwebvh-rs = { version = "0.6.0", default-features = false }
 ```
 
 ## Convenience API
@@ -114,7 +127,7 @@ See the `examples/update_did.rs`, `examples/rotate_keys.rs`, and
 
 ## Updating a DID Programmatically
 
-The `update` module provides [`update_did()`] for programmatic DID updates,
+The `update` module provides `update_did()` for programmatic DID updates,
 complementing `create_did()`. It handles document changes, key rotation,
 parameter updates, domain migration, deactivation, and witness signing:
 
@@ -220,7 +233,7 @@ DID creation and management experience as the built-in wizard.
 
 ```toml
 [dependencies]
-didwebvh-rs = { version = "0.4.1", features = ["cli"] }
+didwebvh-rs = { version = "0.6.0", features = ["cli"] }
 ```
 
 ### Interactive DID Creation
@@ -389,9 +402,9 @@ let signing_key = Secret::generate_ed25519(None, None);
 
 // Build parameters with the signing key as an update key
 let parameters = Parameters {
-    update_keys: Some(Arc::new(vec![
+    update_keys: Some(Arc::new(vec![Multibase::new(
         signing_key.get_public_keymultibase().unwrap(),
-    ])),
+    )])),
     portable: Some(true),
     ..Default::default()
 };
@@ -421,11 +434,12 @@ let config = CreateDIDConfig::builder()
     .build()
     .unwrap();
 
-let result = create_did(config).unwrap();
+let result = create_did(config).await.unwrap();
 
-// result.did        — the resolved DID identifier (with SCID)
-// result.log_entry  — the signed first log entry (serialize to JSON for did.jsonl)
-// result.witness_proofs — witness proofs (empty if no witnesses configured)
+// Access results via accessor methods
+println!("Created DID: {}", result.did());
+result.log_entry().save_to_file("did.jsonl")?;
+result.witness_proofs().save_to_file("did-witness.json")?;
 ```
 
 ### Bring Your Own Signer (HSM / KMS)
@@ -506,7 +520,7 @@ enable only for interop testing with other PQC-aware implementations.
 
 ```toml
 [dependencies]
-didwebvh-rs = { version = "0.5.0", features = ["experimental-pqc"] }
+didwebvh-rs = { version = "0.6.0", features = ["experimental-pqc"] }
 ```
 
 Key generation, signing, and verification flow through the same
@@ -561,12 +575,40 @@ use affinidi_data_integrity::crypto_suites::CryptoSuite;
 let options = WitnessVerifyOptions::new()
     .with_extra_allowed_suite(CryptoSuite::MlDsa44Jcs2024);
 
+// `validate_with` takes `&mut self`, so `state` must be a `mut` binding
+let mut state = DIDWebVHState::default();
 state.validate_with(&options)?.assert_complete()?;
 ```
 
 Accepting non-spec witness suites is deliberate spec-deviation; it's an
 escape hatch for testing, not a production recommendation. Strict
 `state.validate()?` keeps the `eddsa-jcs-2022`-only default.
+
+## Conformance
+
+`tests/test_suite_interop.rs` runs the committed
+[didwebvh-test-suite](https://github.com/decentralized-identity/didwebvh-test-suite)
+vectors: **13 of 13 scenarios, none ignored**.
+
+One scenario is asserted to **fail**, deliberately. The `witness-update` vector
+contains a log entry that lowers its *own* witness configuration — from
+`{threshold: 2, witnesses: [A, B]}` to `{threshold: 1, witnesses: [A]}` — and
+supplies a single proof. Its expected result has that entry resolving. This
+resolver rejects it.
+
+didwebvh 1.0 requires proofs "from a threshold of the **then active**
+witnesses", and specifies that changing a DID's witnesses takes effect only
+*after* the entry declaring the change is published. The then-active threshold
+for that entry is therefore 2, and only one proof is present.
+
+The stricter reading matters: if an entry's own witness configuration governed
+its own approval, an attacker holding a compromised update key could publish
+`{threshold: 1, witnesses: [attacker]}`, sign the single required proof, and
+have it accepted — bypassing witnessing entirely. Containing exactly that
+compromise is what witnesses are for.
+
+If you are comparing this implementation against another and see a divergence
+on `witness-update`, this is why.
 
 ## Fuzzing
 
@@ -601,11 +643,11 @@ cargo +nightly fuzz run chain_validate -- -max_total_time=300
 ```
 
 To drive the verifier from an in-memory chain (in a harness or a test), use
-[`DIDWebVHState::from_log_entries`] with a `Vec<LogEntry>`, then call
+`DIDWebVHState::from_log_entries()` with a `Vec<LogEntry>`, then call
 `validate()`. See `fuzz/README.md` for details.
 
 ## License
 
 Licensed under:
 
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- Apache License, Version 2.0, ([LICENSE](LICENSE) or <https://www.apache.org/licenses/LICENSE-2.0>)

--- a/src/cli_create.rs
+++ b/src/cli_create.rs
@@ -6,9 +6,10 @@
  *
  * # Usage
  *
- * ```ignore
+ * ```no_run
  * use didwebvh_rs::cli_create::{InteractiveCreateConfig, interactive_create_did};
  *
+ * # async fn run() -> Result<(), didwebvh_rs::DIDWebVHError> {
  * // Fully interactive - all values prompted
  * let result = interactive_create_did(InteractiveCreateConfig::default()).await?;
  * println!("Created DID: {}", result.did());
@@ -24,6 +25,8 @@
  *     .portable(true)
  *     .build();
  * let result = interactive_create_did(config).await?;
+ * # Ok(())
+ * # }
  * ```
  *
  * # Placeholder Rewriting
@@ -59,7 +62,7 @@ use url::Url;
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::cli_create::VerificationRelationship;
 ///
 /// let rels = vec![
@@ -101,9 +104,9 @@ impl VerificationRelationship {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::cli_create::{VerificationMethodInput, VerificationRelationship};
-/// use didwebvh_rs::affinidi_secrets_resolver::secrets::Secret;
+/// use didwebvh_rs::prelude::Secret;
 ///
 /// let key = Secret::generate_ed25519(None, None);
 /// let vm = VerificationMethodInput {
@@ -136,14 +139,21 @@ pub struct VerificationMethodInput {
 ///
 /// Fully interactive (all values prompted via terminal):
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::cli_create::{InteractiveCreateConfig, interactive_create_did};
+///
+/// # async fn run() -> Result<(), didwebvh_rs::DIDWebVHError> {
 /// let config = InteractiveCreateConfig::default();
 /// let result = interactive_create_did(config).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Pre-configured with custom services and address (remaining values prompted):
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::cli_create::InteractiveCreateConfig;
+///
 /// let config = InteractiveCreateConfig::builder()
 ///     .address("https://example.com/")
 ///     .service(serde_json::json!({
@@ -158,7 +168,11 @@ pub struct VerificationMethodInput {
 ///
 /// Fully pre-configured (no prompts triggered):
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::cli_create::{InteractiveCreateConfig, VerificationMethodInput};
+/// use didwebvh_rs::prelude::Secret;
+///
+/// # fn demo(signing_key: Secret, vm_input: VerificationMethodInput) {
 /// let config = InteractiveCreateConfig::builder()
 ///     .address("https://example.com/")
 ///     .authorization_key(signing_key)
@@ -174,6 +188,7 @@ pub struct VerificationMethodInput {
 ///     .also_known_as_web(true)
 ///     .also_known_as_scid(false)
 ///     .build();
+/// # }
 /// ```
 #[derive(Default)]
 pub struct InteractiveCreateConfig {
@@ -497,12 +512,15 @@ impl InteractiveCreateResult {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::prelude::*;
 ///
+/// # async fn run() -> Result<(), DIDWebVHError> {
 /// let result = interactive_create_did(InteractiveCreateConfig::default()).await?;
 /// println!("Created DID: {}", result.did());
 /// result.log_entry().save_to_file("did.jsonl")?;
+/// # Ok(())
+/// # }
 /// ```
 pub async fn interactive_create_did(
     config: InteractiveCreateConfig,

--- a/src/cli_update.rs
+++ b/src/cli_update.rs
@@ -13,19 +13,23 @@
  *
  * # Usage
  *
- * ```ignore
- * use didwebvh_rs::cli_update::{InteractiveUpdateConfig, interactive_update_did};
+ * ```no_run
+ * use didwebvh_rs::DIDWebVHState;
+ * use didwebvh_rs::cli_update::{InteractiveUpdateConfig, UpdateSecrets, interactive_update_did};
  *
+ * # async fn run(webvh_state: DIDWebVHState, update_secrets: UpdateSecrets)
+ * #     -> Result<(), didwebvh_rs::DIDWebVHError> {
  * // Fully interactive - loads state from files, prompts for operation
  * let result = interactive_update_did(InteractiveUpdateConfig::default()).await?;
  *
  * // Pre-loaded state with secrets provided
  * let config = InteractiveUpdateConfig::builder()
  *     .state(webvh_state)
- *     .authorization_secrets(auth_secrets)
- *     .witness_secrets(witness_secrets)
+ *     .secrets(update_secrets)
  *     .build();
  * let result = interactive_update_did(config).await?;
+ * # Ok(())
+ * # }
  * ```
  */
 
@@ -56,7 +60,7 @@ use url::Url;
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::cli_update::UpdateOperation;
 ///
 /// let op = UpdateOperation::Modify;
@@ -79,10 +83,11 @@ pub enum UpdateOperation {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::cli_update::UpdateSecrets;
-/// use didwebvh_rs::affinidi_secrets_resolver::secrets::Secret;
+/// use didwebvh_rs::prelude::Secret;
 ///
+/// # fn demo(witness_key: Secret) -> Result<(), Box<dyn std::error::Error>> {
 /// let mut secrets = UpdateSecrets::default();
 ///
 /// // Add an authorization key
@@ -96,6 +101,8 @@ pub enum UpdateOperation {
 ///
 /// // Add a witness secret
 /// secrets.witnesses.insert("did:key:z6Mk...".to_string(), witness_key);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct UpdateSecrets {
@@ -139,25 +146,46 @@ impl UpdateSecrets {
 ///
 /// Fully interactive (loads from files, prompts for everything):
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::cli_update::{InteractiveUpdateConfig, interactive_update_did};
+///
+/// # async fn run() -> Result<(), didwebvh_rs::DIDWebVHError> {
 /// let config = InteractiveUpdateConfig::default();
 /// let result = interactive_update_did(config).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Pre-loaded state with specific operation:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::DIDWebVHState;
+/// use didwebvh_rs::cli_update::{
+///     InteractiveUpdateConfig, UpdateOperation, UpdateSecrets, interactive_update_did,
+/// };
+///
+/// # async fn run(webvh_state: DIDWebVHState, update_secrets: UpdateSecrets)
+/// #     -> Result<(), didwebvh_rs::DIDWebVHError> {
 /// let config = InteractiveUpdateConfig::builder()
 ///     .state(webvh_state)
 ///     .secrets(update_secrets)
 ///     .operation(UpdateOperation::Modify)
 ///     .build();
 /// let result = interactive_update_did(config).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Pre-configured migration:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::DIDWebVHState;
+/// use didwebvh_rs::cli_update::{
+///     InteractiveUpdateConfig, UpdateOperation, UpdateSecrets, interactive_update_did,
+/// };
+///
+/// # async fn run(webvh_state: DIDWebVHState, update_secrets: UpdateSecrets)
+/// #     -> Result<(), didwebvh_rs::DIDWebVHError> {
 /// let config = InteractiveUpdateConfig::builder()
 ///     .state(webvh_state)
 ///     .secrets(update_secrets)
@@ -165,6 +193,8 @@ impl UpdateSecrets {
 ///     .new_url("https://new-domain.example.com/")
 ///     .build();
 /// let result = interactive_update_did(config).await?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Default)]
 pub struct InteractiveUpdateConfig {
@@ -320,15 +350,18 @@ impl InteractiveUpdateResult {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use didwebvh_rs::prelude::*;
 ///
+/// # async fn run() -> Result<(), DIDWebVHError> {
 /// // Fully interactive - loads from files
 /// let result = interactive_update_did(InteractiveUpdateConfig::default()).await?;
 ///
 /// // Save updated state
 /// result.log_entry().save_to_file("did.jsonl")?;
 /// result.state().witness_proofs().save_to_file("did-witness.json")?;
+/// # Ok(())
+/// # }
 /// ```
 pub async fn interactive_update_did(
     config: InteractiveUpdateConfig,
@@ -475,12 +508,26 @@ async fn do_modify(
     let new_params = prompt_update_parameters(previous, secrets)?;
 
     // Find signing key
+    // A deactivated DID has an empty `update_keys` set, and the authorization-key
+    // prompt allows deselecting every key — both leave `active_update_keys`
+    // empty. Indexing `[0]` here used to panic instead of erroring.
+    let active_key = new_params
+        .active_update_keys
+        .first()
+        .ok_or_else(|| {
+            DIDWebVHError::DIDError(
+                "No active update keys are available to sign this update. A deactivated DID \
+                 cannot be updated, and at least one authorization key must be selected."
+                    .to_string(),
+            )
+        })?
+        .clone();
+
     let signing_key = secrets
-        .find_by_public_key(new_params.active_update_keys[0].as_str())
+        .find_by_public_key(active_key.as_str())
         .ok_or_else(|| {
             DIDWebVHError::DIDError(format!(
-                "No signing key found for active update key: {}",
-                new_params.active_update_keys[0]
+                "No signing key found for active update key: {active_key}"
             ))
         })?
         .clone();
@@ -609,12 +656,26 @@ async fn do_migrate(
     let mut new_params = Parameters::default();
     prompt_update_authorization_keys(&last_entry.validated_parameters, &mut new_params, secrets)?;
 
+    // A deactivated DID has an empty `update_keys` set, and the authorization-key
+    // prompt allows deselecting every key — both leave `active_update_keys`
+    // empty. Indexing `[0]` here used to panic instead of erroring.
+    let active_key = new_params
+        .active_update_keys
+        .first()
+        .ok_or_else(|| {
+            DIDWebVHError::DIDError(
+                "No active update keys are available to sign this update. A deactivated DID \
+                 cannot be updated, and at least one authorization key must be selected."
+                    .to_string(),
+            )
+        })?
+        .clone();
+
     let signing_key = secrets
-        .find_by_public_key(new_params.active_update_keys[0].as_str())
+        .find_by_public_key(active_key.as_str())
         .ok_or_else(|| {
             DIDWebVHError::DIDError(format!(
-                "No signing key found for active update key: {}",
-                new_params.active_update_keys[0]
+                "No signing key found for active update key: {active_key}"
             ))
         })?
         .clone();

--- a/src/create.rs
+++ b/src/create.rs
@@ -51,7 +51,12 @@ pub struct CreateDIDConfig<A: Signer = Secret, W: Signer = Secret> {
 /// All other fields have sensible defaults.
 ///
 /// # Example
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+/// # use serde_json::Value;
+///
+/// # fn run(signing_key: Secret, doc: Value, params: Parameters)
+/// #     -> Result<(), DIDWebVHError> {
 /// let config = CreateDIDConfig::builder()
 ///     .address("https://example.com/")
 ///     .authorization_key(signing_key)
@@ -59,6 +64,8 @@ pub struct CreateDIDConfig<A: Signer = Secret, W: Signer = Secret> {
 ///     .parameters(params)
 ///     .also_known_as_web(true)
 ///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct CreateDIDConfigBuilder<A: Signer = Secret, W: Signer = Secret> {
     address: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,26 +56,6 @@ pub use validate::{TruncationReason, ValidationReport};
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-/// One-release-only deprecation shim for code that used to reach for
-/// `didwebvh_rs::affinidi_secrets_resolver::*`.
-///
-/// Removed in 0.6.0. The replacement is either:
-/// - `use didwebvh_rs::prelude::Secret;` (and friends), or
-/// - a direct `affinidi-secrets-resolver` dependency in your own `Cargo.toml`
-///   if you need the full surface.
-///
-/// Rationale for the re-exported whole crate being deprecated:
-/// tying `didwebvh_rs::affinidi_secrets_resolver` to whatever we pin made
-/// downstream version skew silent and painful. Depending on the upstream
-/// crate directly makes the version visible in your `Cargo.lock`.
-#[deprecated(
-    since = "0.5.0",
-    note = "use `didwebvh_rs::prelude::Secret` (and friends) or depend on \
-            `affinidi-secrets-resolver` directly; this re-export will be \
-            removed in 0.6.0"
-)]
-pub use affinidi_secrets_resolver;
-
 // `pub(crate)` re-exports for items that are used widely across this crate's
 // internal modules but are NOT part of the stable top-level public API.
 // Downstream consumers should reach for `didwebvh_rs::prelude::*` (or depend
@@ -148,7 +128,12 @@ pub(crate) fn ensure_object_mut(
 }
 
 /// Error types for WebVH method
+///
+/// This enum is `#[non_exhaustive]`: new variants may be added in future
+/// minor releases without a breaking change, so downstream `match`
+/// expressions must include a wildcard `_ =>` arm.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DIDWebVHError {
     /// The DID has been deactivated and can no longer be resolved.
     #[error("DeactivatedError: {0}")]

--- a/src/log_entry/read.rs
+++ b/src/log_entry/read.rs
@@ -46,6 +46,24 @@ impl LogEntry {
         Ok(entries)
     }
 
+    /// Returns the version number the successor of `previous_id` must carry.
+    ///
+    /// `previous_id` is parsed from an untrusted `versionId` string and can be
+    /// any `u32`, so a bare `previous_id + 1` overflows at `u32::MAX` — a
+    /// panic in debug builds, and a silent wrap to `0` in release builds that
+    /// would let a chain restart its numbering. `verify_log_entry` is public
+    /// and takes `previous_log_entry` from the caller, and the `arbitrary`
+    /// fuzz harness builds entries directly, so this is reachable without
+    /// going through normal chain resolution.
+    fn expected_next_version_id(previous_id: u32) -> Result<u32, DIDWebVHError> {
+        previous_id.checked_add(1).ok_or_else(|| {
+            DIDWebVHError::ValidationError(format!(
+                "Previous LogEntry version ID ({previous_id}) is at the maximum value; \
+                 no valid successor exists",
+            ))
+        })
+    }
+
     /// Verify a LogEntry against a previous entry if it exists
     /// NOTE: THIS DOES NOT VERIFY WITNESS PROOFS!
     /// NOTE: You must validate witness proofs separately
@@ -249,7 +267,9 @@ impl LogEntry {
         if let Some(previous) = previous {
             let (id, _) = previous.get_version_id_fields()?;
 
-            if current_id != id + 1 {
+            let expected_id = LogEntry::expected_next_version_id(id)?;
+
+            if current_id != expected_id {
                 return Err(DIDWebVHError::ValidationError(format!(
                     "Current LogEntry version ID ({current_id}) must be one greater than previous version ID ({id})",
                 )));
@@ -481,6 +501,38 @@ mod tests {
             state: json!({"id": "did:webvh:abc123:example.com"}),
             proof: vec![],
         })
+    }
+
+    /// Tests that the successor-version computation errors at `u32::MAX`
+    /// instead of overflowing.
+    ///
+    /// The versionId is attacker-controlled (it is parsed straight out of the
+    /// log), so the old bare `id + 1` panicked in debug builds and silently
+    /// wrapped to `0` in release builds. The wrap is the dangerous case: it
+    /// would accept a successor numbered `0` and let a chain restart its
+    /// numbering.
+    #[test]
+    fn expected_next_version_id_errors_at_u32_max() {
+        let Err(DIDWebVHError::ValidationError(msg)) = LogEntry::expected_next_version_id(u32::MAX)
+        else {
+            panic!("expected a ValidationError at u32::MAX");
+        };
+        assert!(
+            msg.contains("maximum value"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// The normal path must still increment by exactly one, including at the
+    /// boundary just below the overflow.
+    #[test]
+    fn expected_next_version_id_increments_normally() {
+        assert_eq!(LogEntry::expected_next_version_id(0).unwrap(), 1);
+        assert_eq!(LogEntry::expected_next_version_id(1).unwrap(), 2);
+        assert_eq!(
+            LogEntry::expected_next_version_id(u32::MAX - 1).unwrap(),
+            u32::MAX
+        );
     }
 
     /// Tests that verify_log_entry rejects proofs with any proofPurpose other

--- a/src/log_entry_state/mod.rs
+++ b/src/log_entry_state/mod.rs
@@ -11,7 +11,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Tracks validation status of a LogEntry
+///
+/// This enum is `#[non_exhaustive]`: new validation states may be added in
+/// future minor releases, so downstream `match` expressions must include a
+/// wildcard `_ =>` arm.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
 pub enum LogEntryValidationStatus {
     /// LogEntry failed validation
     Invalid(String),

--- a/src/resolve/implicit.rs
+++ b/src/resolve/implicit.rs
@@ -27,7 +27,7 @@
 //! ## Hash safety
 //!
 //! These services are **never** folded back into the LogEntry's stored `state`.
-//! [`update_implicit_services`] mutates the *caller's* `new_state` `Value`,
+//! `update_implicit_services` mutates the *caller's* `new_state` `Value`,
 //! which is constructed fresh by [`get_did_document`]/[`to_web_did`] from a
 //! clone of `state`. The signed/hashed bytes are taken from `state` directly,
 //! so implicit injection cannot affect the entry hash, the SCID, or any

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,10 +9,12 @@
  *
  * # Example
  *
- * ```ignore
+ * ```no_run
  * use didwebvh_rs::prelude::*;
  * use didwebvh_rs::update::{UpdateDIDConfig, update_did};
  *
+ * # async fn run(webvh_state: DIDWebVHState, current_key: Secret, new_key_multibase: Multibase)
+ * #     -> Result<(), DIDWebVHError> {
  * // Rotate keys
  * let config = UpdateDIDConfig::builder()
  *     .state(webvh_state)
@@ -20,6 +22,8 @@
  *     .update_keys(vec![new_key_multibase])
  *     .build()?;
  * let result = update_did(config).await?;
+ * # Ok(())
+ * # }
  * ```
  */
 
@@ -45,43 +49,70 @@ use url::Url;
 ///
 /// Update the DID document:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+/// use didwebvh_rs::update::{UpdateDIDConfig, update_did};
+/// # use serde_json::Value;
+///
+/// # async fn run(webvh_state: DIDWebVHState, key: Secret, new_doc: Value)
+/// #     -> Result<(), DIDWebVHError> {
 /// let config = UpdateDIDConfig::builder()
 ///     .state(webvh_state)
 ///     .signing_key(key)
 ///     .document(new_doc)
 ///     .build()?;
 /// let result = update_did(config).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Rotate authorization keys:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+/// use didwebvh_rs::update::UpdateDIDConfig;
+///
+/// # fn run(webvh_state: DIDWebVHState, current_key: Secret, new_key_multibase: Multibase)
+/// #     -> Result<(), DIDWebVHError> {
 /// let config = UpdateDIDConfig::builder()
 ///     .state(webvh_state)
 ///     .signing_key(current_key)
 ///     .update_keys(vec![new_key_multibase])
 ///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Deactivate a DID:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+/// use didwebvh_rs::update::UpdateDIDConfig;
+///
+/// # fn run(webvh_state: DIDWebVHState, key: Secret) -> Result<(), DIDWebVHError> {
 /// let config = UpdateDIDConfig::builder()
 ///     .state(webvh_state)
 ///     .signing_key(key)
 ///     .deactivate(true)
 ///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Migrate to a new domain:
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+/// use didwebvh_rs::update::UpdateDIDConfig;
+///
+/// # fn run(webvh_state: DIDWebVHState, key: Secret) -> Result<(), DIDWebVHError> {
 /// let config = UpdateDIDConfig::builder()
 ///     .state(webvh_state)
 ///     .signing_key(key)
 ///     .migrate_to("https://new-domain.example.com/")
 ///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct UpdateDIDConfig<A: Signer = Secret, W: Signer = Secret> {
     /// The DID WebVH state to update (must have at least one log entry).
@@ -339,9 +370,13 @@ impl UpdateDIDResult {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
 /// use didwebvh_rs::update::{UpdateDIDConfig, update_did};
+/// # use serde_json::Value;
 ///
+/// # async fn run(webvh_state: DIDWebVHState, key: Secret, new_doc: Value)
+/// #     -> Result<(), DIDWebVHError> {
 /// // Update the document
 /// let result = update_did(
 ///     UpdateDIDConfig::builder()
@@ -354,6 +389,8 @@ impl UpdateDIDResult {
 /// // Save results
 /// result.log_entry().save_to_file("did.jsonl")?;
 /// result.state().witness_proofs().save_to_file("did-witness.json")?;
+/// # Ok(())
+/// # }
 /// ```
 pub async fn update_did<A: Signer, W: Signer>(
     mut config: UpdateDIDConfig<A, W>,
@@ -377,7 +414,7 @@ pub async fn update_did<A: Signer, W: Signer>(
         .map(|e| e.validated_parameters.clone())
         .ok_or_else(|| DIDWebVHError::LogEntryError("No log entries exist".to_string()))?;
 
-    let document = config.document.unwrap_or_else(|| {
+    let document = config.document.take().unwrap_or_else(|| {
         config
             .state
             .log_entries()
@@ -388,24 +425,7 @@ pub async fn update_did<A: Signer, W: Signer>(
     });
 
     let mut params = last_params;
-    if let Some(keys) = config.update_keys {
-        params.update_keys = Some(Arc::new(keys));
-    }
-    if let Some(hashes) = config.next_key_hashes {
-        params.next_key_hashes = Some(Arc::new(hashes));
-    }
-    if let Some(witness) = config.witness {
-        params.witness = Some(Arc::new(witness));
-    }
-    if let Some(watchers) = config.watchers {
-        params.watchers = Some(Arc::new(watchers));
-    }
-    if let Some(ttl) = config.ttl {
-        params.ttl = Some(ttl);
-    }
-    if let Some(portable) = config.portable {
-        params.portable = Some(portable);
-    }
+    apply_param_overrides(&mut params, &mut config);
 
     config
         .state
@@ -419,6 +439,37 @@ pub async fn update_did<A: Signer, W: Signer>(
 }
 
 /// Handle DID migration to a new domain.
+/// Overlays the caller's requested parameter changes onto `params`.
+///
+/// Each field is taken from `config`, so this must only be called once per
+/// update. Shared by the standard update path and by `do_migrate` — these were
+/// previously two copy-pasted blocks, and the migrate copy silently omitted
+/// `portable`, so `.migrate_to(..).disable_portability()` dropped the
+/// portability change without error.
+fn apply_param_overrides<A: Signer, W: Signer>(
+    params: &mut Parameters,
+    config: &mut UpdateDIDConfig<A, W>,
+) {
+    if let Some(keys) = config.update_keys.take() {
+        params.update_keys = Some(Arc::new(keys));
+    }
+    if let Some(hashes) = config.next_key_hashes.take() {
+        params.next_key_hashes = Some(Arc::new(hashes));
+    }
+    if let Some(witness) = config.witness.take() {
+        params.witness = Some(Arc::new(witness));
+    }
+    if let Some(watchers) = config.watchers.take() {
+        params.watchers = Some(Arc::new(watchers));
+    }
+    if let Some(ttl) = config.ttl.take() {
+        params.ttl = Some(ttl);
+    }
+    if let Some(portable) = config.portable.take() {
+        params.portable = Some(portable);
+    }
+}
+
 async fn do_migrate<A: Signer, W: Signer>(
     mut config: UpdateDIDConfig<A, W>,
     new_address: String,
@@ -475,21 +526,7 @@ async fn do_migrate<A: Signer, W: Signer>(
 
     // Build parameters (apply any additional changes from config)
     let mut params = last_entry.validated_parameters.clone();
-    if let Some(keys) = config.update_keys {
-        params.update_keys = Some(Arc::new(keys));
-    }
-    if let Some(hashes) = config.next_key_hashes {
-        params.next_key_hashes = Some(Arc::new(hashes));
-    }
-    if let Some(witness) = config.witness {
-        params.witness = Some(Arc::new(witness));
-    }
-    if let Some(watchers) = config.watchers {
-        params.watchers = Some(Arc::new(watchers));
-    }
-    if let Some(ttl) = config.ttl {
-        params.ttl = Some(ttl);
-    }
+    apply_param_overrides(&mut params, &mut config);
 
     config
         .state

--- a/src/url.rs
+++ b/src/url.rs
@@ -6,7 +6,8 @@ use url::Url;
 type QueryPairs = (Option<String>, Option<DateTime<FixedOffset>>, Option<u32>);
 
 /// Distinguishes the type of resource a WebVH URL points to.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum URLType {
     /// Regular DID Documentation lookup
     DIDDoc,
@@ -16,7 +17,7 @@ pub enum URLType {
 }
 
 /// Breakdown of a WebVH URL into its components
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WebVHURL {
     /// What type of URL is this?
     pub type_: URLType,
@@ -593,9 +594,7 @@ mod tests {
             "did:webvh:scid:169%2E254%2E169%2E254",
             "did:webvh:scid:127%2E0%2E0%2E1%3A8080",
         ] {
-            let err = WebVHURL::parse_did_url(did)
-                .err()
-                .expect("must be rejected at parse time");
+            let err = WebVHURL::parse_did_url(did).expect_err("must be rejected at parse time");
             assert!(
                 err.to_string().contains("IP addresses are not allowed"),
                 "{did} -> {err}"
@@ -613,9 +612,7 @@ mod tests {
             "did:webvh:scid:127.1",
             "did:webvh:scid:0177.0.0.1",
         ] {
-            let err = WebVHURL::parse_did_url(did)
-                .err()
-                .expect("must be rejected at parse time");
+            let err = WebVHURL::parse_did_url(did).expect_err("must be rejected at parse time");
             assert!(
                 err.to_string().contains("IP addresses are not allowed"),
                 "{did} -> {err}"
@@ -863,7 +860,7 @@ mod tests {
         let result = WebVHURL::parse_did_url(
             "did:webvh:scid:example.com?versionId=1-xyz&versionTime=2024-01-01T00:00:00Z",
         );
-        let err = result.err().expect("expected error");
+        let err = result.expect_err("expected error");
         assert!(
             err.to_string()
                 .contains("Only one of versionId, versionTime, or versionNumber")
@@ -874,7 +871,7 @@ mod tests {
     fn parse_query_version_id_and_version_number_rejects() {
         let result =
             WebVHURL::parse_did_url("did:webvh:scid:example.com?versionId=1-xyz&versionNumber=5");
-        let err = result.err().expect("expected error");
+        let err = result.expect_err("expected error");
         assert!(
             err.to_string()
                 .contains("Only one of versionId, versionTime, or versionNumber")
@@ -886,7 +883,7 @@ mod tests {
         let result = WebVHURL::parse_did_url(
             "did:webvh:scid:example.com?versionTime=2024-01-01T00:00:00Z&versionNumber=5",
         );
-        let err = result.err().expect("expected error");
+        let err = result.expect_err("expected error");
         assert!(
             err.to_string()
                 .contains("Only one of versionId, versionTime, or versionNumber")
@@ -898,7 +895,7 @@ mod tests {
         let result = WebVHURL::parse_did_url(
             "did:webvh:scid:example.com?versionId=1-xyz&versionTime=2024-01-01T00:00:00Z&versionNumber=5",
         );
-        let err = result.err().expect("expected error");
+        let err = result.expect_err("expected error");
         assert!(
             err.to_string()
                 .contains("Only one of versionId, versionTime, or versionNumber")
@@ -922,21 +919,21 @@ mod tests {
     #[test]
     fn parse_did_url_rejects_ipv4() {
         let result = WebVHURL::parse_did_url("did:webvh:scid:192.168.1.1");
-        let err = result.err().expect("expected error for IPv4 address");
+        let err = result.expect_err("expected error for IPv4 address");
         assert!(err.to_string().contains("IP addresses are not allowed"));
     }
 
     #[test]
     fn parse_did_url_rejects_ipv4_loopback() {
         let result = WebVHURL::parse_did_url("did:webvh:scid:127.0.0.1");
-        let err = result.err().expect("expected error for IPv4 loopback");
+        let err = result.expect_err("expected error for IPv4 loopback");
         assert!(err.to_string().contains("IP addresses are not allowed"));
     }
 
     #[test]
     fn parse_did_url_rejects_ipv4_with_port() {
         let result = WebVHURL::parse_did_url("did:webvh:scid:192.168.1.1%3A8080");
-        let err = result.err().expect("expected error for IPv4 with port");
+        let err = result.expect_err("expected error for IPv4 with port");
         assert!(err.to_string().contains("IP addresses are not allowed"));
     }
 
@@ -956,7 +953,7 @@ mod tests {
     fn parse_url_rejects_ipv4() {
         let url = Url::parse("https://192.168.1.1/").unwrap();
         let result = WebVHURL::parse_url(&url);
-        let err = result.err().expect("expected error for IPv4 address");
+        let err = result.expect_err("expected error for IPv4 address");
         assert!(err.to_string().contains("IP addresses are not allowed"));
     }
 
@@ -964,7 +961,7 @@ mod tests {
     fn parse_url_rejects_ipv6() {
         let url = Url::parse("https://[::1]/").unwrap();
         let result = WebVHURL::parse_url(&url);
-        let err = result.err().expect("expected error for IPv6 address");
+        let err = result.expect_err("expected error for IPv6 address");
         assert!(err.to_string().contains("IP addresses are not allowed"));
     }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -91,7 +91,10 @@ impl TruncationReason {
 ///
 /// # Handling the report
 ///
-/// ```ignore
+/// ```no_run
+/// use didwebvh_rs::prelude::*;
+///
+/// # fn run(state: &mut DIDWebVHState) -> Result<(), DIDWebVHError> {
 /// // Strict: fail on any truncation (recommended for resolvers).
 /// state.validate()?.assert_complete()?;
 ///
@@ -100,6 +103,8 @@ impl TruncationReason {
 /// if let Some(reason) = &report.truncated {
 ///     tracing::warn!(?reason, "partial validation");
 /// }
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # On `#[must_use]`

--- a/tests/revoked.rs
+++ b/tests/revoked.rs
@@ -9,6 +9,7 @@ use chrono::{Duration, Utc};
 use didwebvh_rs::{DIDWebVHState, Multibase, parameters::Parameters};
 use serde_json::{Value, json};
 use std::sync::Arc;
+use tempfile::{TempDir, tempdir};
 
 /// Generate an ed25519 Secret with a proper `did:key:...#...` id
 /// so that the DataIntegrityProof verification_method matches the format
@@ -130,39 +131,52 @@ async fn build_revoked_did() -> (DIDWebVHState, String) {
     (state, did)
 }
 
-/// Save log entries to a test file
-fn save_to_file(state: &DIDWebVHState, path: &str) {
+/// Write the log entries to a fresh file inside a caller-owned `TempDir`.
+///
+/// `LogEntry::save_to_file` *appends*, so these tests must never write to a
+/// path that a previous run may have left behind — appending a second copy of
+/// the log produces a corrupt chain and the resolve fails. They previously
+/// wrote to fixed paths under the git-tracked `tests/test_vectors/` and only
+/// removed the file after the assertion, so any failed or interrupted run
+/// poisoned every subsequent run. `TempDir` gives each run a unique directory
+/// and removes it on drop, including on panic.
+fn save_to_temp(state: &DIDWebVHState) -> (TempDir, String) {
+    let dir = tempdir().expect("Failed to create temp dir");
+    let path = dir
+        .path()
+        .join("did.jsonl")
+        .to_str()
+        .expect("Temp path is not valid UTF-8")
+        .to_string();
+
     for entry in state.log_entries() {
         entry
             .log_entry
-            .save_to_file(path)
+            .save_to_file(&path)
             .expect("Failed to save log entry");
     }
+
+    (dir, path)
 }
 
 #[tokio::test]
 async fn test_revoked_did() {
-    let path = "tests/test_vectors/revoked-did-test1.jsonl";
     let (state, did) = build_revoked_did().await;
-    save_to_file(&state, path);
+    let (_dir, path) = save_to_temp(&state);
 
     let mut resolver = DIDWebVHState::default();
     let (_, metadata) = resolver
-        .resolve_file(&did, path, None)
+        .resolve_file(&did, &path, None)
         .await
         .expect("Couldn't resolve revoked DID");
-
-    // Clean up
-    let _ = std::fs::remove_file(path);
 
     assert!(metadata.deactivated);
 }
 
 #[tokio::test]
 async fn test_revoked_status_earlier_version() {
-    let path = "tests/test_vectors/revoked-did-test2.jsonl";
     let (state, did) = build_revoked_did().await;
-    save_to_file(&state, path);
+    let (_dir, path) = save_to_temp(&state);
 
     // Query version 2 — even though it wasn't itself deactivated,
     // the DID-level deactivation should still be reported
@@ -171,12 +185,9 @@ async fn test_revoked_status_earlier_version() {
 
     let mut resolver = DIDWebVHState::default();
     let (_, metadata) = resolver
-        .resolve_file(&did_with_version, path, None)
+        .resolve_file(&did_with_version, &path, None)
         .await
         .expect("Couldn't resolve revoked DID at earlier version");
-
-    // Clean up
-    let _ = std::fs::remove_file(path);
 
     assert!(metadata.deactivated);
 }

--- a/tests/test_suite_interop.rs
+++ b/tests/test_suite_interop.rs
@@ -97,6 +97,40 @@ async fn run(scenario: &str, assert_did_document: bool) {
     }
 }
 
+/// Resolves a scenario expecting failure, returning the error string.
+///
+/// Used for fixtures whose committed `resolutionResult.json` this
+/// implementation deliberately does not reproduce — see `witness_update`.
+async fn run_expect_error(scenario: &str) -> String {
+    let dir = format!("{ROOT}/{scenario}");
+    let jsonl = std::fs::read_to_string(format!("{dir}/did.jsonl"))
+        .unwrap_or_else(|e| panic!("read did.jsonl for {scenario}: {e}"));
+    let witness = std::fs::read_to_string(format!("{dir}/did-witness.json")).ok();
+    let expected: Value = {
+        let s = std::fs::read_to_string(format!("{dir}/resolutionResult.json"))
+            .unwrap_or_else(|e| panic!("read resolutionResult.json for {scenario}: {e}"));
+        serde_json::from_str(&s)
+            .unwrap_or_else(|e| panic!("parse resolutionResult.json for {scenario}: {e}"))
+    };
+    let did = expected
+        .pointer("/didDocument/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("{scenario}: no didDocument.id in expected result"))
+        .to_string();
+
+    let mut state = DIDWebVHState::default();
+    match state
+        .resolve_log_owned(&did, &jsonl, witness.as_deref())
+        .await
+    {
+        Ok((_, meta)) => panic!(
+            "{scenario}: expected resolution to fail, but it resolved to {}",
+            meta.version_id
+        ),
+        Err(e) => format!("{e:?}"),
+    }
+}
+
 /// Rewrites `service[].id` values of `"#files"`/`"#whois"` to their
 /// absolute form `"<did>#files"`/`"<did>#whois"`. Only the two implicit
 /// service names are touched — user-supplied relative IDs (e.g.
@@ -158,11 +192,47 @@ async fn services() {
     run("services", true).await;
 }
 
+/// Deliberate divergence from the committed fixture — this asserts a security
+/// property, not a parity failure.
+///
+/// The `witness-update` vector's entry 2 lowers its own witness config from
+/// `{threshold: 2, witnesses: [A, B]}` to `{threshold: 1, witnesses: [A]}` and
+/// supplies a single proof (from A). Its `resolutionResult.json` expects
+/// version 2 to resolve, which means the reference generator evaluated entry 2
+/// against the *new* config it declares.
+///
+/// This resolver evaluates it against the previously-active config
+/// (threshold 2) and rejects it, per didwebvh 1.0:
+///
+/// - "the resolver MUST confirm that the `did-witness.json` file contains
+///   verified witness Data Integrity proofs from a threshold of the **then
+///   active** witnesses"
+/// - "rotating the keys authorized to update a DID or changing the witnesses
+///   for a DID take effect only *after* the entry in which they are defined
+///   has been published"
+///
+/// Accepting the fixture's reading would make witnessing bypassable: an
+/// attacker holding a compromised update key could publish an entry setting
+/// `{threshold: 1, witnesses: [attacker]}`, sign the single required proof
+/// themselves, and have it accepted — defeating the entire purpose of the
+/// witness mechanism. The whole point of witnesses is to bound the damage
+/// from exactly that compromise.
+///
+/// This test therefore pins the rejection. If it starts failing because the
+/// entry now resolves, that is a genuine security regression, not a fixture
+/// drift. The previous `#[ignore]` on this test also misdiagnosed the cause
+/// ("witness proof signature on entry 2 fails verification") — the signature
+/// is fine; the threshold is not met.
+///
+/// Tracked upstream: the vector and the spec's normative text disagree, and
+/// the discrepancy should be raised against didwebvh-test-suite.
 #[tokio::test]
-#[ignore = "witness proof signature on entry 2 fails verification; \
-            out of v0.5.1 scope, tracked as follow-up (tasks/todo.md)"]
-async fn witness_update() {
-    run("witness-update", false).await;
+async fn witness_update_rejects_self_lowered_threshold() {
+    let err = run_expect_error("witness-update").await;
+    assert!(
+        err.contains("threshold") && err.contains("not met"),
+        "expected a witness-threshold rejection, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/tests/update_did.rs
+++ b/tests/update_did.rs
@@ -8,6 +8,7 @@
 use affinidi_secrets_resolver::secrets::Secret;
 use didwebvh_rs::{
     DIDWebVHState, Multibase,
+    log_entry::LogEntryMethods,
     parameters::Parameters,
     update::{UpdateDIDConfig, update_did},
     witness::Witnesses,
@@ -313,6 +314,63 @@ async fn disable_portability() {
 
     let result = update_did(config).await.unwrap();
     assert_eq!(result.state().log_entries().len(), 2);
+}
+
+/// Regression test: `migrate_to` used to run its own copy-pasted parameter
+/// overlay that omitted `portable`, so combining a migration with
+/// `disable_portability()` silently dropped the portability change and the
+/// migrated DID stayed portable. Both paths now share
+/// `apply_param_overrides`.
+#[tokio::test]
+async fn migrate_applies_disable_portability() {
+    let (state, key, _) = create_test_did(true).await; // portable
+
+    let config = UpdateDIDConfig::builder()
+        .state(state)
+        .signing_key(key)
+        .migrate_to("https://new.example.com/")
+        .disable_portability()
+        .build()
+        .unwrap();
+
+    let result = update_did(config).await.unwrap();
+
+    // The migration itself still happened.
+    assert!(result.did().contains("new.example.com"));
+
+    // ...and the portability change was NOT dropped.
+    let params = result.log_entry().get_parameters();
+    assert_eq!(
+        params.portable,
+        Some(false),
+        "disable_portability() must be honoured on the migrate path, not silently discarded"
+    );
+}
+
+/// The migrate path must carry through every other overlay field too, not just
+/// `portable` — this pins the shared-helper behaviour so a future divergence
+/// between the two paths fails loudly.
+#[tokio::test]
+async fn migrate_applies_other_param_overrides() {
+    let (state, key, _) = create_test_did(true).await;
+
+    let config = UpdateDIDConfig::builder()
+        .state(state)
+        .signing_key(key)
+        .migrate_to("https://new.example.com/")
+        .ttl(3600)
+        .watchers(vec!["https://watcher.example.com".to_string()])
+        .build()
+        .unwrap();
+
+    let result = update_did(config).await.unwrap();
+    let params = result.log_entry().get_parameters();
+
+    assert_eq!(params.ttl, Some(3600));
+    assert_eq!(
+        params.watchers.as_ref().map(|w| w.as_slice().to_vec()),
+        Some(vec!["https://watcher.example.com".to_string()])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Bumps `affinidi-did-common` from `"0.3"` to `"0.4"` and `affinidi-data-integrity`
from `"0.7"` to `"0.7.7"`, **plus a pre-release audit pass** over dependencies,
documentation, and code quality.

Releases as **`0.6.0`**, not `0.5.8` — see [Why the version moved](#why-the-version-moved).

Both upstream dependencies are now published, so CI should be green and
`Cargo.lock` has been regenerated (this PR originally left it untouched
deliberately, because it could not be regenerated honestly until they landed).

## Why the version moved

The audit fixes include `#[non_exhaustive]` on public enums that shipped through
0.5.7. That breaks downstream code matching them exhaustively, so shipping it in
a patch release would violate semver. Doing it now — rather than deferring —
means future variants of `DIDWebVHError` no longer force a major bump each time.

This also triggers removal of the `affinidi_secrets_resolver` re-export, which
was deprecated in 0.5.0 with `"removed in 0.6.0"` in both its doc comment and
its `#[deprecated]` note.

### Breaking changes

- `DIDWebVHError`, `URLType` and `LogEntryValidationStatus` are now
  `#[non_exhaustive]`. Downstream `match` expressions need a `_ =>` arm.
- The `didwebvh_rs::affinidi_secrets_resolver` re-export is removed. Replace
  with `didwebvh_rs::prelude::Secret`, or depend on `affinidi-secrets-resolver`
  directly. README carries a migration note.

## Fixed

- **`update_did()` silently discarded `portable` on the migrate path.**
  `do_migrate` carried its own copy-pasted parameter-overlay block that omitted
  the `portable` arm, so `.migrate_to(..).disable_portability()` built and ran
  successfully while dropping the portability change. Both paths now share a
  single `apply_param_overrides` helper. The regression test was verified to
  fail without the fix.
- **`u32` overflow in the successor-version check.** `versionId` is parsed from
  the untrusted log and `verify_log_entry` is public, so a bare `id + 1` was
  reachable with attacker-controlled input: a panic in debug builds, and a
  silent wrap to `0` in release builds that would let a chain restart its
  numbering.
- **Two panics in the interactive CLI update flow.** `active_update_keys[0]`
  was indexed unconditionally; a deactivated DID (empty `update_keys`) or
  deselecting every key in the prompt produced an index-out-of-bounds panic
  instead of an error.

## Conformance: `witness-update` is now asserted to fail

The `witness-update` interop test was `#[ignore]`d with the reason *"witness
proof signature on entry 2 fails verification"*. That diagnosis was wrong — the
signature verifies fine. The actual failure is a witness **threshold** mismatch,
and it is correct behaviour.

Entry 2 of that vector lowers its own witness config from
`{threshold: 2, witnesses: [A, B]}` to `{threshold: 1, witnesses: [A]}` and
supplies one proof. The committed `resolutionResult.json` expects it to resolve,
i.e. the generator evaluated the entry against the *new* config it declares.

didwebvh 1.0 says otherwise:

> the resolver MUST confirm that the `did-witness.json` file contains verified
> witness Data Integrity proofs from a threshold of the **then active** witnesses

> rotating the keys authorized to update a DID or changing the witnesses for a
> DID take effect only *after* the entry in which they are defined has been
> published

The then-active threshold for entry 2 is 2; one proof is present; it is
rejected. **Accepting the fixture's reading would make witnessing bypassable** —
an attacker holding a compromised update key could publish
`{threshold: 1, witnesses: [attacker]}`, sign the single required proof
themselves, and have it accepted. Bounding exactly that compromise is the point
of the witness mechanism.

So rather than weakening the verifier to match the fixture, the test is
un-ignored and inverted: `witness_update_rejects_self_lowered_threshold` pins
the rejection. If it ever starts passing by resolving, that is a security
regression, not fixture drift. **The discrepancy should be raised against
didwebvh-test-suite.**

Interop suite is now **13/13 with nothing ignored**.

## Documentation

- Fixed README examples that **could not compile**: `create_did()` shown without
  `.await`; `CreateDIDResult` shown accessing `did` / `log_entry` /
  `witness_proofs` as fields when they are `pub(crate)`; `update_keys` built
  from a bare `String` instead of a `Multibase`.
- Fixed the MSRV badge (1.94.0 → 1.95.0), a dead `LICENSE-APACHE` link, stale
  versions in four install snippets, two rustdoc intra-doc links that render
  broken in plain Markdown, and an incomplete prelude listing.
- **Converted all 22 `` ```ignore `` doctests to `` ```no_run ``.** Doctests went
  from 2 passing / 22 ignored to **24 passing / 0 ignored**. This is what let the
  README bugs above survive; the conversion immediately surfaced a documented
  builder method (`.authorization_secrets()` / `.witness_secrets()`) that does
  not exist — the real API is a single `.secrets()`.
- Added a README "Conformance" section documenting the `witness-update`
  divergence for anyone comparing implementations.

## Tests

- **Fixed an intermittent failure in `tests/revoked.rs`.** `LogEntry::save_to_file`
  *appends*, the tests wrote to fixed paths under the git-tracked
  `tests/test_vectors/`, and cleanup ran only *after* the assertion — so any
  failed or interrupted run left a file the next run appended to, producing a
  corrupt chain. Self-perpetuating once triggered. Each test now gets its own
  `TempDir`, removed on drop including on panic.
- Added regression coverage for the `portable`-on-migrate fix, the other overlay
  fields on the migrate path, and the `u32::MAX` boundary.

## Dependencies & CI

- Direct deps refreshed: `async-trait` 0.1.91, `serde` 1.0.229, `thiserror`
  2.0.19, `tokio` 1.53.0, plus `anyhow`/`clap` dev-side. `tempfile` added as a
  dev-dependency.
- **Dropped four stale `--ignore` flags from the CI audit job**
  (`RUSTSEC-2026-0098/0099/0104`, `RUSTSEC-2025-0134`). Those were rooted in the
  reqwest 0.11 chain, which disappeared when this crate moved to reqwest 0.13; a
  current audit does not report them. Stale ignores silently mask an advisory if
  the dependency ever returns.
- Gated the nightly-only bench behind a `nightly` feature, so
  `cargo check/clippy --all-targets` now works on stable instead of failing with
  E0554.

## Publish ordering

1. ~~`affinidi-did-common 0.4.0`~~ ✅ published
2. ~~`affinidi-data-integrity 0.7.7`~~ ✅ published
3. **this** — `didwebvh-rs 0.6.0`
4. affinidi-tdk-rs [#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629) then resolves and merges

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-features --tests --examples -- -D warnings` clean
- **528 tests + 24 doctests passing**, 3 ignored (all network-gated)
- `cargo audit` clean under the trimmed ignore list
- MSRV 1.95.0 builds; `--no-default-features` builds; `--all-targets` builds on stable
- Packages at 297 KiB

### Not done, deliberately

`ResolveOptions` was **not** made `#[non_exhaustive]`. It is a config struct with
public fields, and `non_exhaustive` forbids struct-literal construction
downstream entirely — even with `..Default::default()`. `examples/resolve.rs`
uses exactly that pattern, so it is the documented public idiom. The right
version of that change is `non_exhaustive` *plus* a builder, which is a larger
API addition than belongs in this release.
